### PR TITLE
Collect all yml files

### DIFF
--- a/util/metadata.go
+++ b/util/metadata.go
@@ -14,8 +14,8 @@ const url = "https://api.github.com/repos/web-platform-tests/wpt-metadata/tarbal
 
 // CollectMetadata iterates through wpt-metadata repository and returns a
 // map that maps a test path to its META.yml file content.
-func CollectMetadata() (res map[string][]byte, err error) {
-	resp, err := http.Get(url)
+func CollectMetadata(client *http.Client) (res map[string][]byte, err error) {
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -16,7 +16,6 @@ const url = "https://api.github.com/repos/web-platform-tests/wpt-metadata/tarbal
 // CollectMetadata iterates through wpt-metadata repository and returns a
 // map that maps a test path to its META.yml file content.
 func CollectMetadata() (res map[string][]byte, err error) {
-
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"	
+	"io/ioutil"
+	"strings"
+)
+
+func CheckError(err error) {
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+// CollectMetadata iterates through wpt-metadata repository and returns a
+// map that maps a test path to its META.yml file content.
+func CollectMetadata() map[string][]byte{
+	ymlFiles := []string{}
+	curPath, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+
+	rootDor := filepath.Dir(filepath.Dir(curPath))
+	walkErr := filepath.Walk(rootDor, func(path string, f os.FileInfo, err error) error {
+		if f.Name() == "META.yml" {
+			ymlFiles = append(ymlFiles, path)
+		}	
+        return err
+	})
+	CheckError(walkErr)
+
+	ymlMap := make(map[string][]byte)
+	for _, file := range ymlFiles {
+		data, err := ioutil.ReadFile(file)
+		CheckError(err)
+		testPath := strings.TrimPrefix(file, rootDor)
+		ymlMap[testPath] = data 
+	}
+	return ymlMap
+}
+
+func main() {
+	fmt.Println(CollectMetadata())
+}

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -62,6 +62,7 @@ func CollectMetadata() (res map[string][]byte, err error) {
 
 		// Removes `owner-repo` prefix in the file name.
 		relativeFileName := header.Name[strings.Index(header.Name, "/")+1:]
+		relativeFileName = strings.TrimSuffix(relativeFileName, "/META.yml")
 		metadataMap[relativeFileName] = data
 	}
 

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import (
 	"fmt"
@@ -39,8 +39,4 @@ func CollectMetadata() map[string][]byte{
 		ymlMap[testPath] = data 
 	}
 	return ymlMap
-}
-
-func main() {
-	fmt.Println(CollectMetadata())
 }

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -13,6 +13,7 @@ func CheckError(err error) {
 		fmt.Println(err)
 	}
 }
+
 // CollectMetadata iterates through wpt-metadata repository and returns a
 // map that maps a test path to its META.yml file content.
 func CollectMetadata() map[string][]byte{

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -1,42 +1,79 @@
 package util
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"io/ioutil"
-	"os"
-	"path/filepath"
+	"net/http"
 	"strings"
 )
 
+const url = "https://api.github.com/repos/web-platform-tests/wpt-metadata/tarball"
+
 // CollectMetadata iterates through wpt-metadata repository and returns a
 // map that maps a test path to its META.yml file content.
-func CollectMetadata() map[string][]byte {
-	ymlFiles := []string{}
-	curPath, err := os.Executable()
+func CollectMetadata() (res map[string][]byte, err error) {
+
+	resp, err := http.Get(url)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	rootDir := filepath.Dir(filepath.Dir(curPath))
-	walkErr := filepath.Walk(rootDir, func(path string, f os.FileInfo, err error) error {
-		if f.Name() == "META.yml" {
-			ymlFiles = append(ymlFiles, path)
+	statusCode := resp.StatusCode
+	// The statuscode could be one of redirect codes.
+	if !(statusCode == 200 || (statusCode >= 300 && statusCode <= 308)) {
+		err := fmt.Errorf("Bad status code:%d, Unable to download wpt-metadata", statusCode)
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	gzip, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer gzip.Close()
+
+	tarReader := tar.NewReader(gzip)
+	var metadataMap = make(map[string][]byte)
+	for {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
 		}
-		return err
-	})
-	if walkErr != nil {
-		fmt.Println(walkErr)
-	}
 
-	ymlMap := make(map[string][]byte)
-	for _, file := range ymlFiles {
-		data, err := ioutil.ReadFile(file)
 		if err != nil {
-			fmt.Println(err)
+			return nil, err
 		}
-		testPath := strings.TrimPrefix(file, rootDir)
-		ymlMap[testPath] = data
+
+		// Not a regular file.
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		if !strings.HasSuffix(header.Name, "META.yml") {
+			continue
+		}
+
+		data := make([]byte, header.Size)
+
+		_, err = tarReader.Read(data)
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Removes `owner-repo` prefix in the file name.
+		relativeFileName := header.Name[strings.Index(header.Name, "/")+1:]
+		metadataMap[relativeFileName] = data
 	}
 
-	return ymlMap
+	return metadataMap, nil
 }

--- a/util/metadata.go
+++ b/util/metadata.go
@@ -2,42 +2,41 @@ package util
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"	
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
-func CheckError(err error) {
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
 // CollectMetadata iterates through wpt-metadata repository and returns a
 // map that maps a test path to its META.yml file content.
-func CollectMetadata() map[string][]byte{
+func CollectMetadata() map[string][]byte {
 	ymlFiles := []string{}
 	curPath, err := os.Executable()
 	if err != nil {
 		panic(err)
 	}
 
-	rootDor := filepath.Dir(filepath.Dir(curPath))
-	walkErr := filepath.Walk(rootDor, func(path string, f os.FileInfo, err error) error {
+	rootDir := filepath.Dir(filepath.Dir(curPath))
+	walkErr := filepath.Walk(rootDir, func(path string, f os.FileInfo, err error) error {
 		if f.Name() == "META.yml" {
 			ymlFiles = append(ymlFiles, path)
-		}	
-        return err
+		}
+		return err
 	})
-	CheckError(walkErr)
+	if walkErr != nil {
+		fmt.Println(walkErr)
+	}
 
 	ymlMap := make(map[string][]byte)
 	for _, file := range ymlFiles {
 		data, err := ioutil.ReadFile(file)
-		CheckError(err)
-		testPath := strings.TrimPrefix(file, rootDor)
-		ymlMap[testPath] = data 
+		if err != nil {
+			fmt.Println(err)
+		}
+		testPath := strings.TrimPrefix(file, rootDir)
+		ymlMap[testPath] = data
 	}
+
 	return ymlMap
 }


### PR DESCRIPTION
Download wpt-metadata repos and collect all YML files for wpt.fyi to use.

When running wpt.fyi, a timeout should be created to call this method and retrieve the latest wpt-metadata repository.