### PR TITLE
Add entries-api Chrome-only failure

### DIFF
--- a/entries-api/META.yml
+++ b/entries-api/META.yml
@@ -1,0 +1,5 @@
+links:
+  - product: chrome
+    test: interfaces.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=652814


### PR DESCRIPTION
Issue 652814: Rename FileEntry to FileSystemEntry (and friends), drop [NoInterfaceObject]
https://bugs.chromium.org/p/chromium/issues/detail?id=652814

From
https://wpt.fyi/results/entries-api/interfaces.html?q=%28chrome%3A%21pass%26chrome%3A%21ok%29+%28firefox%3Apass%7Cfirefox%3Aok%29+%28safari%3Apass%7Csafari%3Aok%29&run_id=4531892908982272&run_id=6566352210886656&run_id=4736764862267392