### PR TITLE
Add clear-site-data

### DIFF
--- a/clear-site-data/META.yml
+++ b/clear-site-data/META.yml
@@ -1,0 +1,5 @@
+links:
+  - product: chrome
+    test: storage.https.html
+    status: TIMEOUT
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=767040

--- a/clear-site-data/META.yml
+++ b/clear-site-data/META.yml
@@ -1,5 +1,6 @@
 links:
   - product: chrome
-    test: storage.https.html
-    status: TIMEOUT
     url: https://bugs.chromium.org/p/chromium/issues/detail?id=767040
+    results:
+    - test: storage.https.html
+      status: TIMEOUT


### PR DESCRIPTION
Adds a link to Chrome's flaky `TIMEOUT` result bug.

This is actually the example surfaced in the design doc:
https://docs.google.com/document/d/1oWYVkc2ztANCGUxwNVTQHlWV32zq6Ifq9jkkbYNbSAg/edit#heading=h.3ckhkm75kph6