### PR TITLE
Add css/css-fonts/META.yml

### DIFF
--- a/css/css-fonts/META.yml
+++ b/css/css-fonts/META.yml
@@ -1,0 +1,17 @@
+links:
+  - product: chrome
+    test: font-synthesis-01.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989
+  - product: chrome
+    test: font-synthesis-02.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989
+  - product: chrome
+    test: font-synthesis-03.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989
+  - product: chrome
+    test: font-synthesis-04.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989

--- a/css/css-fonts/META.yml
+++ b/css/css-fonts/META.yml
@@ -1,17 +1,12 @@
 links:
   - product: chrome
-    test: font-synthesis-01.html
-    status: FAIL
     url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989
-  - product: chrome
-    test: font-synthesis-02.html
-    status: FAIL
-    url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989
-  - product: chrome
-    test: font-synthesis-03.html
-    status: FAIL
-    url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989
-  - product: chrome
-    test: font-synthesis-04.html
-    status: FAIL
-    url: https://bugs.chromium.org/p/chromium/issues/detail?id=509989
+    results:
+    - test: font-synthesis-01.html
+      status: FAIL
+    - test: font-synthesis-02.html
+      status: FAIL
+    - test: font-synthesis-03.html
+      status: FAIL
+    - test: font-synthesis-04.html
+      status: FAIL


### PR DESCRIPTION
Contains chrome-specific failures for font-synthesis tests, linking to the implementation tracking bug in Chromium.