### PR TITLE
Add workers metadata

### DIFF
--- a/workers/META.yml
+++ b/workers/META.yml
@@ -1,0 +1,5 @@
+links:
+  - product: chrome
+    test: interfaces.worker.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=114475

--- a/workers/META.yml
+++ b/workers/META.yml
@@ -1,5 +1,6 @@
 links:
   - product: chrome
-    test: interfaces.worker.html
-    status: FAIL
     url: https://bugs.chromium.org/p/chromium/issues/detail?id=114475
+    result:
+    - status: FAIL
+      test: interfaces.worker.html

--- a/workers/META.yml
+++ b/workers/META.yml
@@ -1,6 +1,6 @@
 links:
   - product: chrome
     url: https://bugs.chromium.org/p/chromium/issues/detail?id=114475
-    result:
+    results:
     - status: FAIL
       test: interfaces.worker.html

--- a/workers/constructors/Worker/META.yml
+++ b/workers/constructors/Worker/META.yml
@@ -1,5 +1,6 @@
 links:
   - product: chrome
-    test: DedicatedWorkerGlobalScope-members.worker.html
-    status: FAIL
     url: https://bugs.chromium.org/p/chromium/issues/detail?id=114475
+    results:
+    - test: DedicatedWorkerGlobalScope-members.worker.html
+      status: FAIL

--- a/workers/constructors/Worker/META.yml
+++ b/workers/constructors/Worker/META.yml
@@ -1,0 +1,5 @@
+links:
+  - product: chrome
+    test: DedicatedWorkerGlobalScope-members.worker.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=114475


### PR DESCRIPTION
Adds chrome-only failures from https://wpt.fyi/results/workers?q=%28chrome%3A%21pass%26chrome%3A%21ok%29+%28firefox%3Apass%7Cfirefox%3Aok%29+%28safari%3Apass%7Csafari%3Aok%29&run_id=234620010&run_id=238650013&run_id=228920010