### PR TITLE
Add link for webusb usb.serviceworker.https.html failure

### DIFF
--- a/webusb/META.yml
+++ b/webusb/META.yml
@@ -1,5 +1,6 @@
 links:
   - product: chrome
-    test:  usb.serviceworker.https.html
-    status: FAIL
     url: https://bugs.chromium.org/p/chromium/issues/detail?id=839117
+    results:
+    - test:  usb.serviceworker.https.html
+      status: FAIL

--- a/webusb/META.yml
+++ b/webusb/META.yml
@@ -1,0 +1,5 @@
+links:
+  - product: chrome
+    test:  usb.serviceworker.https.html
+    status: FAIL
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=839117


### PR DESCRIPTION
Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=839117
Note; Chrome's the only implementer, so the only one that _could_ fail this test.