### PR TITLE
Add bug for FileAPI Chrome MISSING results

### DIFF
--- a/FileAPI/blob/META.yml
+++ b/FileAPI/blob/META.yml
@@ -1,0 +1,10 @@
+links:
+  - product: chrome
+    url: https://github.com/web-platform-tests/results-collection/issues/661
+    results:
+    - test: Blob-constructor.html
+      subtest: Blob with type "image/gif;"
+      status: MISSING
+    - test: Blob-slice.html
+      subtest: Invalid contentType ("text/plain")
+      status: MISSING

--- a/FileAPI/blob/META.yml
+++ b/FileAPI/blob/META.yml
@@ -3,8 +3,8 @@ links:
     url: https://github.com/web-platform-tests/results-collection/issues/661
     results:
     - test: Blob-constructor.html
-      subtest: Blob with type "image/gif;"
+      subtest: Blob with type "image/gif;"
       status: MISSING
     - test: Blob-slice.html
-      subtest: Invalid contentType ("text/plain")
+      subtest: Invalid contentType ("text/plain")
       status: MISSING


### PR DESCRIPTION
Non-printable char in the subtest name survives in Chrome's result set, but not other browsers.
https://github.com/web-platform-tests/results-collection/issues/661