### PR TITLE
Add test for paths being in the manifest

### DIFF
--- a/WebIDL/META.yml
+++ b/WebIDL/META.yml
@@ -2,5 +2,5 @@ links:
   - product: chrome
     url: https://bugs.chromium.org/p/chromium/issues/detail?id=793204
     results:
-    - test: default-iterator-object.html
+    - test: ecmascript-binding/default-iterator-object.html
       status: FAIL

--- a/dom/META.yml
+++ b/dom/META.yml
@@ -2,13 +2,21 @@ links:
 - product: firefox
   results:
   - subtest: 'Document interface: attribute origin'
-    test: interfaces.html
+    test: interfaces.html?include=Node
   - subtest: 'Document interface: xmlDoc must inherit property "origin" with the proper
       type (3)'
-    test: interfaces.html
+    test: interfaces.html?include=Node
   - subtest: 'Document interface: new Document() must inherit property "origin" with
       the proper type (3)'
-    test: interfaces.html
+    test: interfaces.html?include=Node
+  - subtest: 'Document interface: attribute origin'
+    test: interfaces.html?exclude=Node
+  - subtest: 'Document interface: xmlDoc must inherit property "origin" with the proper
+      type (3)'
+    test: interfaces.html?exclude=Node
+  - subtest: 'Document interface: new Document() must inherit property "origin" with
+      the proper type (3)'
+    test: interfaces.html?exclude=Node
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=931884
 - product: firefox
   results:

--- a/dom/META.yml
+++ b/dom/META.yml
@@ -2,14 +2,6 @@ links:
 - product: firefox
   results:
   - subtest: 'Document interface: attribute origin'
-    test: interfaces.html?include=Node
-  - subtest: 'Document interface: xmlDoc must inherit property "origin" with the proper
-      type (3)'
-    test: interfaces.html?include=Node
-  - subtest: 'Document interface: new Document() must inherit property "origin" with
-      the proper type (3)'
-    test: interfaces.html?include=Node
-  - subtest: 'Document interface: attribute origin'
     test: interfaces.html?exclude=Node
   - subtest: 'Document interface: xmlDoc must inherit property "origin" with the proper
       type (3)'

--- a/test_paths_test.go
+++ b/test_paths_test.go
@@ -1,0 +1,115 @@
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-yaml/yaml"
+	"github.com/stretchr/testify/assert"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// TestResultsTestPaths enumerates all the metadata in the repo and ensures that
+// a test by the given name exists in the latest manifest.
+func TestResultsTestPaths(t *testing.T) {
+	log.Println("Fetching latest manifest...")
+	resp, err := http.Get("https://wpt.fyi/api/manifest?sha=latest")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	sha := resp.Header.Get("x-wpt-sha")
+	if sha == "" {
+		sha = shared.LatestSHA
+	} else {
+		sha = sha[:7]
+	}
+
+	t.Run(fmt.Sprintf("Manifest @ %s", sha), func(t *testing.T) {
+		unmarshalled := shared.Manifest{}
+		err := json.Unmarshal(data, &unmarshalled)
+		if err != nil {
+			panic(err)
+		}
+
+		validPaths := mapset.NewSet()
+		manifestItems := []shared.ManifestItem{
+			unmarshalled.Items.Manual,
+			unmarshalled.Items.Reftest,
+			unmarshalled.Items.TestHarness,
+			unmarshalled.Items.WDSpec,
+		}
+		for _, m := range manifestItems {
+			if m == nil {
+				continue
+			}
+			for _, items := range m {
+				for _, item := range items {
+					var url string
+					if err = json.Unmarshal(*item[0], &url); err != nil {
+						continue
+					}
+					validPaths.Add(url)
+				}
+			}
+		}
+		log.Printf("Found %v test paths", validPaths.Cardinality())
+
+		// Crawl + test all the metadata
+		filepath.Walk(".", func(filePath string, info os.FileInfo, err error) error {
+			if err != nil {
+				panic(err)
+			} else if info.IsDir() || strings.ToLower(info.Name()) != "meta.yml" {
+				return nil
+			}
+			fileDir := path.Dir(filePath)
+			t.Run(fileDir, func(t *testing.T) {
+				var metadata shared.Metadata
+				f, err := os.Open(filePath)
+				if err != nil {
+					panic(err)
+				}
+				data, err := ioutil.ReadAll(f)
+				if err != nil {
+					panic(err)
+				}
+				err = yaml.Unmarshal(data, &metadata)
+				assert.Nil(t, err)
+
+				for _, link := range metadata.Links {
+					for _, result := range link.Results {
+						if result.TestPath != "" {
+							fullPath := path.Join(fileDir, result.TestPath)
+							t.Run(fullPath, func(t *testing.T) {
+								assert.True(
+									t,
+									validPaths.Contains(fullPath),
+									"%s is not a test path found in the manifest @ %s", fullPath, sha,
+								)
+							})
+						}
+					}
+				}
+			})
+			return nil
+		})
+	})
+}


### PR DESCRIPTION
Grabs the manifest from wpt.fyi/api/manifest, converts it into a set of known test-file names, and then crawl the wpt-metadata repo to ensure that the results paths (relative to their parent folder) are a test path that can be found in the set of known test-file names.

It fails for `IndexedDB/bindings-inject-key.html` as expected, since that file got renamed :)