### PR TITLE
Handle nils in parse_test.go

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -65,7 +65,15 @@ func checkDuplicationAcrossLinks(t *testing.T, link shared.MetadataLink, linkMap
 }
 
 func checkDuplicationWithinResults(t *testing.T, result shared.MetadataTestResult, resultSet mapset.Set) {
-	expected := serializeStrings(result.TestPath, result.SubtestName, result.Status.String())
+	subtestName := ""
+	if result.SubtestName != nil {
+		subtestName = *result.SubtestName
+	}
+	status := ""
+	if result.Status != nil {
+		status = result.Status.String()
+	}
+	expected := serializeStrings(result.TestPath, subtestName, status)
 	assert.False(t, resultSet.Contains(expected), "duplicated entries within results")
 	resultSet.Add(expected)
 }


### PR DESCRIPTION
This is a quick fix for #37 , but doesn't handle the larger problem of versioning wpt.fyi shared code