### PR TITLE
Add metadata with safari and webkitgtk expected failures for css/

### DIFF
--- a/css/WOFF2/META.yml
+++ b/css/WOFF2/META.yml
@@ -1,0 +1,14 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=185938
+  results:
+  - test: directory-knowntags-001.xht
+    status: FAIL
+  - test: tabledata-glyf-bbox-001.xht
+    status: FAIL
+  - test: tabledata-glyf-origlength-001.xht
+    status: FAIL
+  - test: tabledata-glyf-origlength-002.xht
+    status: FAIL
+  - test: tabledata-glyf-origlength-003.xht
+    status: FAIL

--- a/css/css-color/META.yml
+++ b/css/css-color/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=148932
+  results:
+  - test: t425-hsla-clip-outside-device-gamut-b.xht
+    status: FAIL

--- a/css/css-display/META.yml
+++ b/css/css-display/META.yml
@@ -15,3 +15,19 @@ links:
     status: FAIL
   - test: select-4-option-optgroup-display-none.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=157477
+  results:
+  - test: display-contents-dynamic-table-001-inline.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203606
+  results:
+  - test: display-change-object-iframe.html
+    status: FAIL
+  - test: display-contents-shadow-dom-1.html
+    status: TIMEOUT
+  - test: display-flow-root-list-item-001.html
+    status: FAIL
+  - test: select-4-option-optgroup-display-none.html
+    status: FAIL

--- a/css/css-display/META.yml
+++ b/css/css-display/META.yml
@@ -1,0 +1,17 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=157477
+  results:
+  - test: display-contents-dynamic-table-001-inline.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203606
+  results:
+  - test: display-change-object-iframe.html
+    status: FAIL
+  - test: display-contents-shadow-dom-1.html
+    status: CRASH
+  - test: display-flow-root-list-item-001.html
+    status: FAIL
+  - test: select-4-option-optgroup-display-none.html
+    status: FAIL

--- a/css/css-grid/abspos/META.yml
+++ b/css/css-grid/abspos/META.yml
@@ -3,3 +3,10 @@ links:
   results:
   - test: grid-positioned-items-implicit-grid-line-001.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1500622
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=191465
+  results:
+  - test: absolute-positioning-changing-containing-block-001.html
+    status: FAIL
+  - test: grid-item-absolute-positioning-dynamic-001.html
+    status: FAIL

--- a/css/css-grid/abspos/META.yml
+++ b/css/css-grid/abspos/META.yml
@@ -10,3 +10,10 @@ links:
     status: FAIL
   - test: grid-item-absolute-positioning-dynamic-001.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=191465
+  results:
+  - test: absolute-positioning-changing-containing-block-001.html
+    status: FAIL
+  - test: grid-item-absolute-positioning-dynamic-001.html
+    status: FAIL

--- a/css/css-grid/grid-items/META.yml
+++ b/css/css-grid/grid-items/META.yml
@@ -31,3 +31,25 @@ links:
   results:
   - test: explicitly-sized-grid-item-as-table.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=169271
+  results:
+  - test: grid-items-sizing-alignment-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=191365
+  results:
+  - test: item-with-table-with-infinite-max-intrinsic-width.html
+    status: FAIL
+  - test: table-with-infinite-max-intrinsic-width.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=191460
+  results:
+  - test: anonymous-grid-item-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=191463
+  results:
+  - test: explicitly-sized-grid-item-as-table.html
+    status: FAIL

--- a/css/css-grid/grid-items/META.yml
+++ b/css/css-grid/grid-items/META.yml
@@ -1,0 +1,33 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=169271
+  results:
+  - test: grid-items-sizing-alignment-001.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=191365
+  results:
+  - test: item-with-table-with-infinite-max-intrinsic-width.html
+    status: FAIL
+  - test: table-with-infinite-max-intrinsic-width.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=191460
+  results:
+  - test: anonymous-grid-item-001.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=191461
+  results:
+  - test: percentage-size-subitems-001.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=191462
+  results:
+  - test: percentage-size-replaced-subitems-001.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=191463
+  results:
+  - test: explicitly-sized-grid-item-as-table.html
+    status: FAIL

--- a/css/css-grid/grid-model/META.yml
+++ b/css/css-grid/grid-model/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: grid-container-ignores-first-letter-002.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=191367
+  results:
+  - test: grid-container-ignores-first-letter-002.html
+    status: FAIL

--- a/css/css-grid/grid-model/META.yml
+++ b/css/css-grid/grid-model/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=191367
+  results:
+  - test: grid-container-ignores-first-letter-002.html
+    status: FAIL

--- a/css/css-images/META.yml
+++ b/css/css-images/META.yml
@@ -22,3 +22,26 @@ links:
   results:
   - test: multiple-position-color-stop-radial.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=200207
+  results:
+  - test: css-image-fallbacks-and-annotations.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations002.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations003.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations004.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations005.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=200208
+  results:
+  - test: gradients-with-transparent.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=200209
+  results:
+  - test: multiple-position-color-stop-radial.html
+    status: FAIL

--- a/css/css-images/META.yml
+++ b/css/css-images/META.yml
@@ -1,0 +1,24 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=200207
+  results:
+  - test: css-image-fallbacks-and-annotations.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations002.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations003.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations004.html
+    status: FAIL
+  - test: css-image-fallbacks-and-annotations005.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=200208
+  results:
+  - test: gradients-with-transparent.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=200209
+  results:
+  - test: multiple-position-color-stop-radial.html
+    status: FAIL

--- a/css/css-lists/META.yml
+++ b/css/css-lists/META.yml
@@ -1,0 +1,20 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=167729
+  results:
+  - test: list-style-type-string-001a.html
+    status: FAIL
+  - test: list-style-type-string-001b.html
+    status: FAIL
+  - test: list-style-type-string-002.html
+    status: FAIL
+  - test: list-style-type-string-003.html
+    status: FAIL
+  - test: list-style-type-string-005a.html
+    status: FAIL
+  - test: list-style-type-string-005b.html
+    status: FAIL
+  - test: list-style-type-string-006.html
+    status: FAIL
+  - test: list-style-type-string-007.html
+    status: FAIL

--- a/css/css-lists/META.yml
+++ b/css/css-lists/META.yml
@@ -18,3 +18,22 @@ links:
     status: FAIL
   - test: list-style-type-string-007.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=167729
+  results:
+  - test: list-style-type-string-001a.html
+    status: FAIL
+  - test: list-style-type-string-001b.html
+    status: FAIL
+  - test: list-style-type-string-002.html
+    status: FAIL
+  - test: list-style-type-string-003.html
+    status: FAIL
+  - test: list-style-type-string-005a.html
+    status: FAIL
+  - test: list-style-type-string-005b.html
+    status: FAIL
+  - test: list-style-type-string-006.html
+    status: FAIL
+  - test: list-style-type-string-007.html
+    status: FAIL

--- a/css/css-multicol/META.yml
+++ b/css/css-multicol/META.yml
@@ -4,3 +4,13 @@ links:
   results:
   - test: multicol-rule-004.xht
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=153698
+  results:
+  - test: multicol-rule-dashed-000.xht
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=148816
+  results:
+  - test: multicol-rule-004.xht
+    status: FAIL

--- a/css/css-multicol/META.yml
+++ b/css/css-multicol/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=148816
+  results:
+  - test: multicol-rule-004.xht
+    status: FAIL

--- a/css/css-position/META.yml
+++ b/css/css-position/META.yml
@@ -1,0 +1,67 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203447
+  results:
+  - test: position-absolute-dynamic-overflow-001.html
+    status: FAIL
+  - test: position-absolute-dynamic-overflow-002.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203448
+  results:
+  - test: position-absolute-dynamic-static-position-table-cell.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203449
+  results:
+  - test: position-relative-table-tbody-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tbody-left.html
+    status: FAIL
+  - test: position-relative-table-tbody-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tbody-top.html
+    status: FAIL
+  - test: position-relative-table-tfoot-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tfoot-left.html
+    status: FAIL
+  - test: position-relative-table-tfoot-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tfoot-top.html
+    status: FAIL
+  - test: position-relative-table-thead-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-thead-left.html
+    status: FAIL
+  - test: position-relative-table-thead-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-thead-top.html
+    status: FAIL
+  - test: position-relative-table-tr-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tr-left.html
+    status: FAIL
+  - test: position-relative-table-tr-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tr-top.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203450
+  results:
+  - test: position-sticky-hyperlink.html
+    status: FAIL
+  - test: position-sticky-inline.html
+    status: FAIL
+  - test: position-sticky-nested-inline.html
+    status: FAIL
+  - test: position-sticky-nested-table.html
+    status: FAIL
+  - test: position-sticky-rendering.html
+    status: FAIL
+  - test: position-sticky-table-parts.html
+    status: FAIL
+  - test: position-sticky-table-th-bottom.html
+    status: FAIL
+  - test: position-sticky-writing-modes.html
+    status: FAIL

--- a/css/css-position/META.yml
+++ b/css/css-position/META.yml
@@ -65,3 +65,62 @@ links:
     status: FAIL
   - test: position-sticky-writing-modes.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203448
+  results:
+  - test: position-absolute-dynamic-static-position-table-cell.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203449
+  results:
+  - test: position-relative-table-tbody-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tbody-left.html
+    status: FAIL
+  - test: position-relative-table-tbody-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tbody-top.html
+    status: FAIL
+  - test: position-relative-table-tfoot-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tfoot-left.html
+    status: FAIL
+  - test: position-relative-table-tfoot-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tfoot-top.html
+    status: FAIL
+  - test: position-relative-table-thead-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-thead-left.html
+    status: FAIL
+  - test: position-relative-table-thead-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-thead-top.html
+    status: FAIL
+  - test: position-relative-table-tr-left-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tr-left.html
+    status: FAIL
+  - test: position-relative-table-tr-top-absolute-child.html
+    status: FAIL
+  - test: position-relative-table-tr-top.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203450
+  results:
+  - test: position-sticky-hyperlink.html
+    status: FAIL
+  - test: position-sticky-inline.html
+    status: FAIL
+  - test: position-sticky-nested-inline.html
+    status: FAIL
+  - test: position-sticky-nested-table.html
+    status: FAIL
+  - test: position-sticky-rendering.html
+    status: FAIL
+  - test: position-sticky-table-parts.html
+    status: FAIL
+  - test: position-sticky-table-th-bottom.html
+    status: FAIL
+  - test: position-sticky-writing-modes.html
+    status: FAIL

--- a/css/css-position/static-position/META.yml
+++ b/css/css-position/static-position/META.yml
@@ -1,0 +1,28 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203451
+  results:
+  - test: htb-ltr-ltr.html
+    status: FAIL
+  - test: htb-ltr-rtl.tentative.html
+    status: FAIL
+  - test: htb-rtl-ltr.tentative.html
+    status: FAIL
+  - test: htb-rtl-rtl.html
+    status: FAIL
+  - test: vlr-ltr-ltr.html
+    status: FAIL
+  - test: vlr-ltr-rtl.tentative.html
+    status: FAIL
+  - test: vlr-rtl-ltr.tentative.html
+    status: FAIL
+  - test: vlr-rtl-rtl.html
+    status: FAIL
+  - test: vrl-ltr-ltr.html
+    status: FAIL
+  - test: vrl-ltr-rtl.tentative.html
+    status: FAIL
+  - test: vrl-rtl-ltr.tentative.html
+    status: FAIL
+  - test: vrl-rtl-rtl.html
+    status: FAIL

--- a/css/css-position/static-position/META.yml
+++ b/css/css-position/static-position/META.yml
@@ -26,3 +26,30 @@ links:
     status: FAIL
   - test: vrl-rtl-rtl.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203451
+  results:
+  - test: htb-ltr-ltr.html
+    status: FAIL
+  - test: htb-ltr-rtl.tentative.html
+    status: FAIL
+  - test: htb-rtl-ltr.tentative.html
+    status: FAIL
+  - test: htb-rtl-rtl.html
+    status: FAIL
+  - test: vlr-ltr-ltr.html
+    status: FAIL
+  - test: vlr-ltr-rtl.tentative.html
+    status: FAIL
+  - test: vlr-rtl-ltr.tentative.html
+    status: FAIL
+  - test: vlr-rtl-rtl.html
+    status: FAIL
+  - test: vrl-ltr-ltr.html
+    status: FAIL
+  - test: vrl-ltr-rtl.tentative.html
+    status: FAIL
+  - test: vrl-rtl-ltr.tentative.html
+    status: FAIL
+  - test: vrl-rtl-rtl.html
+    status: FAIL

--- a/css/css-shapes/shape-outside/shape-image/META.yml
+++ b/css/css-shapes/shape-outside/shape-image/META.yml
@@ -1,0 +1,37 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=163706
+  results:
+  - test: shape-image-010.html
+    status: FAIL
+  - test: shape-image-024.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203540
+  results:
+  - test: shape-image-000.html
+    status: FAIL
+  - test: shape-image-001.html
+    status: FAIL
+  - test: shape-image-004.html
+    status: FAIL
+  - test: shape-image-006.html
+    status: FAIL
+  - test: shape-image-009.html
+    status: FAIL
+  - test: shape-image-013.html
+    status: FAIL
+  - test: shape-image-015.html
+    status: FAIL
+  - test: shape-image-016.html
+    status: FAIL
+  - test: shape-image-018.html
+    status: FAIL
+  - test: shape-image-021.html
+    status: FAIL
+  - test: shape-image-022.html
+    status: FAIL
+  - test: shape-image-026.html
+    status: FAIL
+  - test: shape-image-027.html
+    status: FAIL

--- a/css/css-shapes/shape-outside/shape-image/META.yml
+++ b/css/css-shapes/shape-outside/shape-image/META.yml
@@ -35,3 +35,13 @@ links:
     status: FAIL
   - test: shape-image-027.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203240
+  results:
+  - test: shape-image-025.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=163706
+  results:
+  - test: shape-image-024.html
+    status: FAIL

--- a/css/css-shapes/shape-outside/shape-image/gradients/META.yml
+++ b/css/css-shapes/shape-outside/shape-image/gradients/META.yml
@@ -1,0 +1,28 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203539
+  results:
+  - test: shape-outside-linear-gradient-005.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-006.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-007.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-008.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-009.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-010.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-011.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-012.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-013.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-014.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-015.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-016.html
+    status: FAIL

--- a/css/css-shapes/shape-outside/shape-image/gradients/META.yml
+++ b/css/css-shapes/shape-outside/shape-image/gradients/META.yml
@@ -26,3 +26,30 @@ links:
     status: FAIL
   - test: shape-outside-linear-gradient-016.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203539
+  results:
+  - test: shape-outside-linear-gradient-005.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-006.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-007.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-008.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-009.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-010.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-011.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-012.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-013.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-014.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-015.html
+    status: FAIL
+  - test: shape-outside-linear-gradient-016.html
+    status: FAIL

--- a/css/css-sizing/META.yml
+++ b/css/css-sizing/META.yml
@@ -57,3 +57,56 @@ links:
   results:
   - test: whitespace-and-break.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203510
+  results:
+  - test: clone-intrinsic-size.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203511
+  results:
+  - test: clone-nowrap-intrinsic-size-bidi.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203508
+  results:
+  - test: image-min-max-content-intrinsic-size-change-001.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-002.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-003.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-004.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-005.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-006.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-007.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-008.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203512
+  results:
+  - test: intrinsic-percent-non-replaced-004.html
+    status: FAIL
+  - test: intrinsic-percent-non-replaced-005.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203514
+  results:
+  - test: range-percent-intrinsic-size-2.html
+    status: FAIL
+  - test: range-percent-intrinsic-size-2a.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203515
+  results:
+  - test: slice-intrinsic-size.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203516
+  results:
+  - test: whitespace-and-break.html
+    status: FAIL

--- a/css/css-sizing/META.yml
+++ b/css/css-sizing/META.yml
@@ -1,0 +1,59 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203509
+  results:
+  - test: auto-scrollbar-inside-stf-abspos.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203510
+  results:
+  - test: clone-intrinsic-size.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203511
+  results:
+  - test: clone-nowrap-intrinsic-size-bidi.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203508
+  results:
+  - test: image-min-max-content-intrinsic-size-change-001.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-002.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-003.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-004.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-005.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-006.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-007.html
+    status: FAIL
+  - test: image-min-max-content-intrinsic-size-change-008.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203512
+  results:
+  - test: intrinsic-percent-non-replaced-004.html
+    status: FAIL
+  - test: intrinsic-percent-non-replaced-005.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203514
+  results:
+  - test: range-percent-intrinsic-size-2.html
+    status: FAIL
+  - test: range-percent-intrinsic-size-2a.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203515
+  results:
+  - test: slice-intrinsic-size.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203516
+  results:
+  - test: whitespace-and-break.html
+    status: FAIL

--- a/css/css-text-decor/META.yml
+++ b/css/css-text-decor/META.yml
@@ -31,3 +31,35 @@ links:
     status: FAIL
   - test: text-decoration-underline-position-vertical.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203530
+  results:
+  - test: text-decoration-line-recalc.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203531
+  results:
+  - test: text-decoration-propagation-shadow.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203528
+  results:
+  - test: text-decoration-thickness-linethrough-001.html
+    status: FAIL
+  - test: text-decoration-thickness-overline-001.html
+    status: FAIL
+  - test: text-decoration-thickness-scroll-001.html
+    status: FAIL
+  - test: text-decoration-thickness-underline-001.html
+    status: FAIL
+  - test: text-decoration-thickness-vertical-001.html
+    status: FAIL
+  - test: text-decoration-thickness-vertical-002.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203529
+  results:
+  - test: text-decoration-underline-position-vertical-ja.html
+    status: FAIL
+  - test: text-decoration-underline-position-vertical.html
+    status: FAIL

--- a/css/css-text-decor/META.yml
+++ b/css/css-text-decor/META.yml
@@ -1,0 +1,33 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203530
+  results:
+  - test: text-decoration-line-recalc.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203531
+  results:
+  - test: text-decoration-propagation-shadow.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203528
+  results:
+  - test: text-decoration-thickness-linethrough-001.html
+    status: FAIL
+  - test: text-decoration-thickness-overline-001.html
+    status: FAIL
+  - test: text-decoration-thickness-scroll-001.html
+    status: FAIL
+  - test: text-decoration-thickness-underline-001.html
+    status: FAIL
+  - test: text-decoration-thickness-vertical-001.html
+    status: FAIL
+  - test: text-decoration-thickness-vertical-002.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203529
+  results:
+  - test: text-decoration-underline-position-vertical-ja.html
+    status: FAIL
+  - test: text-decoration-underline-position-vertical.html
+    status: FAIL

--- a/css/css-text/boundary-shaping/META.yml
+++ b/css/css-text/boundary-shaping/META.yml
@@ -12,3 +12,16 @@ links:
     status: FAIL
   - test: boundary-shaping-010.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: boundary-shaping-001.html
+    status: FAIL
+  - test: boundary-shaping-003.html
+    status: FAIL
+  - test: boundary-shaping-004.html
+    status: FAIL
+  - test: boundary-shaping-005.html
+    status: FAIL
+  - test: boundary-shaping-010.html
+    status: FAIL

--- a/css/css-text/boundary-shaping/META.yml
+++ b/css/css-text/boundary-shaping/META.yml
@@ -1,0 +1,14 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: boundary-shaping-001.html
+    status: FAIL
+  - test: boundary-shaping-003.html
+    status: FAIL
+  - test: boundary-shaping-004.html
+    status: FAIL
+  - test: boundary-shaping-005.html
+    status: FAIL
+  - test: boundary-shaping-010.html
+    status: FAIL

--- a/css/css-text/letter-spacing/META.yml
+++ b/css/css-text/letter-spacing/META.yml
@@ -12,3 +12,21 @@ links:
     status: FAIL
   - test: letter-spacing-nesting-002.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: letter-spacing-control-chars-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: letter-spacing-bidi-001.html
+    status: FAIL
+  - test: letter-spacing-bidi-002.html
+    status: FAIL
+  - test: letter-spacing-end-of-line-001.html
+    status: FAIL
+  - test: letter-spacing-nesting-001.html
+    status: FAIL
+  - test: letter-spacing-nesting-002.html
+    status: FAIL

--- a/css/css-text/letter-spacing/META.yml
+++ b/css/css-text/letter-spacing/META.yml
@@ -1,0 +1,14 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: letter-spacing-bidi-001.html
+    status: FAIL
+  - test: letter-spacing-bidi-002.html
+    status: FAIL
+  - test: letter-spacing-end-of-line-001.html
+    status: FAIL
+  - test: letter-spacing-nesting-001.html
+    status: FAIL
+  - test: letter-spacing-nesting-002.html
+    status: FAIL

--- a/css/css-text/line-break/META.yml
+++ b/css/css-text/line-break/META.yml
@@ -1,0 +1,34 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=198543
+  results:
+  - test: line-break-anywhere-001.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: line-break-strict-011.xht
+    status: FAIL
+  - test: line-break-strict-012.xht
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: line-break-loose-013.xht
+    status: FAIL
+  - test: line-break-loose-014.xht
+    status: FAIL
+  - test: line-break-loose-015.xht
+    status: FAIL
+  - test: line-break-loose-016a.xht
+    status: FAIL
+  - test: line-break-loose-016b.xht
+    status: FAIL
+  - test: line-break-loose-017a.xht
+    status: FAIL
+  - test: line-break-loose-017b.xht
+    status: FAIL
+  - test: line-break-loose-018.xht
+    status: FAIL
+  - test: line-break-normal-013.xht
+    status: FAIL

--- a/css/css-text/line-break/META.yml
+++ b/css/css-text/line-break/META.yml
@@ -32,3 +32,31 @@ links:
     status: FAIL
   - test: line-break-normal-013.xht
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: line-break-strict-011.xht
+    status: FAIL
+  - test: line-break-strict-012.xht
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: line-break-loose-013.xht
+    status: FAIL
+  - test: line-break-loose-014.xht
+    status: FAIL
+  - test: line-break-loose-015.xht
+    status: FAIL
+  - test: line-break-loose-016a.xht
+    status: FAIL
+  - test: line-break-loose-016b.xht
+    status: FAIL
+  - test: line-break-loose-017a.xht
+    status: FAIL
+  - test: line-break-loose-017b.xht
+    status: FAIL
+  - test: line-break-loose-018.xht
+    status: FAIL
+  - test: line-break-normal-013.xht
+    status: FAIL

--- a/css/css-text/line-breaking/META.yml
+++ b/css/css-text/line-breaking/META.yml
@@ -1,0 +1,20 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: line-breaking-002.html
+    status: FAIL
+  - test: line-breaking-004.html
+    status: FAIL
+  - test: line-breaking-006.html
+    status: FAIL
+  - test: line-breaking-007.html
+    status: FAIL
+  - test: line-breaking-009.html
+    status: FAIL
+  - test: line-breaking-011.html
+    status: FAIL
+  - test: line-breaking-ic-002.html
+    status: FAIL
+  - test: line-breaking-ic-003.html
+    status: FAIL

--- a/css/css-text/line-breaking/META.yml
+++ b/css/css-text/line-breaking/META.yml
@@ -18,3 +18,22 @@ links:
     status: FAIL
   - test: line-breaking-ic-003.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: line-breaking-002.html
+    status: FAIL
+  - test: line-breaking-004.html
+    status: FAIL
+  - test: line-breaking-006.html
+    status: FAIL
+  - test: line-breaking-007.html
+    status: FAIL
+  - test: line-breaking-009.html
+    status: FAIL
+  - test: line-breaking-011.html
+    status: FAIL
+  - test: line-breaking-ic-002.html
+    status: FAIL
+  - test: line-breaking-ic-003.html
+    status: FAIL

--- a/css/css-text/overflow-wrap/META.yml
+++ b/css/css-text/overflow-wrap/META.yml
@@ -1,0 +1,23 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=196169
+  results:
+  - test: overflow-wrap-break-word-003.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195345
+  results:
+  - test: overflow-wrap-anywhere-001.html
+    status: FAIL
+  - test: overflow-wrap-anywhere-004.html
+    status: FAIL
+  - test: overflow-wrap-anywhere-005.html
+    status: FAIL
+  - test: overflow-wrap-anywhere-span-001.html
+    status: FAIL
+  - test: overflow-wrap-min-content-size-001.html
+    status: FAIL
+  - test: overflow-wrap-min-content-size-002.html
+    status: FAIL
+  - test: overflow-wrap-min-content-size-003.html
+    status: FAIL

--- a/css/css-text/overflow-wrap/META.yml
+++ b/css/css-text/overflow-wrap/META.yml
@@ -21,3 +21,20 @@ links:
     status: FAIL
   - test: overflow-wrap-min-content-size-003.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195345
+  results:
+  - test: overflow-wrap-anywhere-001.html
+    status: FAIL
+  - test: overflow-wrap-anywhere-003.html
+    status: FAIL
+  - test: overflow-wrap-anywhere-005.html
+    status: FAIL
+  - test: overflow-wrap-anywhere-span-001.html
+    status: FAIL
+  - test: overflow-wrap-min-content-size-001.html
+    status: FAIL
+  - test: overflow-wrap-min-content-size-002.html
+    status: FAIL
+  - test: overflow-wrap-min-content-size-003.html
+    status: FAIL

--- a/css/css-text/tab-size/META.yml
+++ b/css/css-text/tab-size/META.yml
@@ -1,0 +1,8 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: tab-min-rendered-width-1.html
+    status: FAIL
+  - test: tab-size-spacing-001.html
+    status: FAIL

--- a/css/css-text/tab-size/META.yml
+++ b/css/css-text/tab-size/META.yml
@@ -6,3 +6,10 @@ links:
     status: FAIL
   - test: tab-size-spacing-001.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: tab-min-rendered-width-1.html
+    status: FAIL
+  - test: tab-size-spacing-001.html
+    status: FAIL

--- a/css/css-text/text-align/META.yml
+++ b/css/css-text/text-align/META.yml
@@ -1,0 +1,20 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-align-justifyall-001.html
+    status: FAIL
+  - test: text-align-justifyall-002.html
+    status: FAIL
+  - test: text-align-justifyall-003.html
+    status: FAIL
+  - test: text-align-justifyall-004.html
+    status: FAIL
+  - test: text-align-justifyall-005.html
+    status: FAIL
+  - test: text-align-justifyall-006.html
+    status: FAIL
+  - test: text-align-last-010.html
+    status: FAIL
+  - test: text-align-last-011.html
+    status: FAIL

--- a/css/css-text/text-align/META.yml
+++ b/css/css-text/text-align/META.yml
@@ -18,3 +18,22 @@ links:
     status: FAIL
   - test: text-align-last-011.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-align-justifyall-001.html
+    status: FAIL
+  - test: text-align-justifyall-002.html
+    status: FAIL
+  - test: text-align-justifyall-003.html
+    status: FAIL
+  - test: text-align-justifyall-004.html
+    status: FAIL
+  - test: text-align-justifyall-005.html
+    status: FAIL
+  - test: text-align-justifyall-006.html
+    status: FAIL
+  - test: text-align-last-010.html
+    status: FAIL
+  - test: text-align-last-011.html
+    status: FAIL

--- a/css/css-text/text-indent/META.yml
+++ b/css/css-text/text-indent/META.yml
@@ -1,0 +1,15 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-indent-percentage-001.xht
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: text-indent-percentage-002.html
+    status: FAIL
+  - test: text-indent-percentage-003.html
+    status: FAIL
+  - test: text-indent-percentage-004.html
+    status: FAIL

--- a/css/css-text/text-indent/META.yml
+++ b/css/css-text/text-indent/META.yml
@@ -13,3 +13,17 @@ links:
     status: FAIL
   - test: text-indent-percentage-004.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-indent-percentage-001.xht
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: text-indent-percentage-002.html
+    status: FAIL
+  - test: text-indent-percentage-003.html
+    status: FAIL
+  - test: text-indent-percentage-004.html
+    status: FAIL

--- a/css/css-text/text-justify/META.yml
+++ b/css/css-text/text-justify/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: text-justify-001.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-justify-001.html
+    status: FAIL

--- a/css/css-text/text-justify/META.yml
+++ b/css/css-text/text-justify/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-justify-001.html
+    status: FAIL

--- a/css/css-text/text-transform/META.yml
+++ b/css/css-text/text-transform/META.yml
@@ -1,0 +1,45 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-transform-fullwidth-001.xht
+    status: FAIL
+  - test: text-transform-fullwidth-002.xht
+    status: FAIL
+  - test: text-transform-fullwidth-004.xht
+    status: FAIL
+  - test: text-transform-fullwidth-005.xht
+    status: FAIL
+  - test: text-transform-tailoring-001.html
+    status: FAIL
+  - test: text-transform-tailoring-002.html
+    status: FAIL
+  - test: text-transform-tailoring-002a.html
+    status: FAIL
+  - test: text-transform-tailoring-003.html
+    status: FAIL
+  - test: text-transform-tailoring-005.html
+    status: FAIL
+  - test: text-transform-upperlower-006.html
+    status: FAIL
+  - test: text-transform-upperlower-039.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: text-transform-capitalize-033.html
+    status: FAIL
+  - test: text-transform-full-size-kana-001.html
+    status: FAIL
+  - test: text-transform-full-size-kana-002.html
+    status: FAIL
+  - test: text-transform-full-size-kana-003.html
+    status: FAIL
+  - test: text-transform-full-size-kana-004.html
+    status: FAIL
+  - test: text-transform-shaping-001.html
+    status: FAIL
+  - test: text-transform-shaping-002.html
+    status: FAIL
+  - test: text-transform-shaping-003.html
+    status: FAIL

--- a/css/css-text/text-transform/META.yml
+++ b/css/css-text/text-transform/META.yml
@@ -43,3 +43,52 @@ links:
     status: FAIL
   - test: text-transform-shaping-003.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186142
+  results:
+  - test: text-transform-upperlower-016.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: text-transform-fullwidth-001.xht
+    status: FAIL
+  - test: text-transform-fullwidth-002.xht
+    status: FAIL
+  - test: text-transform-fullwidth-004.xht
+    status: FAIL
+  - test: text-transform-fullwidth-005.xht
+    status: FAIL
+  - test: text-transform-tailoring-001.html
+    status: FAIL
+  - test: text-transform-tailoring-002.html
+    status: FAIL
+  - test: text-transform-tailoring-002a.html
+    status: FAIL
+  - test: text-transform-tailoring-003.html
+    status: FAIL
+  - test: text-transform-tailoring-005.html
+    status: FAIL
+  - test: text-transform-upperlower-006.html
+    status: FAIL
+  - test: text-transform-upperlower-039.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: text-transform-capitalize-033.html
+    status: FAIL
+  - test: text-transform-full-size-kana-001.html
+    status: FAIL
+  - test: text-transform-full-size-kana-002.html
+    status: FAIL
+  - test: text-transform-full-size-kana-003.html
+    status: FAIL
+  - test: text-transform-full-size-kana-004.html
+    status: FAIL
+  - test: text-transform-shaping-001.html
+    status: FAIL
+  - test: text-transform-shaping-002.html
+    status: FAIL
+  - test: text-transform-shaping-003.html
+    status: FAIL

--- a/css/css-text/white-space/META.yml
+++ b/css/css-text/white-space/META.yml
@@ -62,3 +62,57 @@ links:
     status: FAIL
   - test: break-spaces-before-first-char-005.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: textarea-pre-wrap-012.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: line-edge-white-space-collapse-001.html
+    status: FAIL
+  - test: line-edge-white-space-collapse-002.html
+    status: FAIL
+  - test: pre-wrap-014.html
+    status: FAIL
+  - test: tab-stop-threshold-002.html
+    status: FAIL
+  - test: tab-stop-threshold-004.html
+    status: FAIL
+  - test: tab-stop-threshold-006.html
+    status: FAIL
+  - test: text-space-collapse-discard-001.xht
+    status: FAIL
+  - test: text-space-collapse-preserve-breaks-001.xht
+    status: FAIL
+  - test: text-space-trim-trim-inner-001.xht
+    status: FAIL
+  - test: trailing-ideographic-space-001.html
+    status: FAIL
+  - test: trailing-ideographic-space-002.html
+    status: FAIL
+  - test: trailing-ideographic-space-003.html
+    status: FAIL
+  - test: trailing-ideographic-space-004.html
+    status: FAIL
+  - test: white-space-intrinsic-size-001.html
+    status: FAIL
+  - test: white-space-pre-wrap-trailing-spaces-002.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195345
+  results:
+  - test: break-spaces-before-first-char-006.html
+    status: FAIL
+  - test: break-spaces-before-first-char-013.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=197277
+  results:
+  - test: break-spaces-008.html
+    status: FAIL
+  - test: break-spaces-before-first-char-004.html
+    status: FAIL
+  - test: break-spaces-before-first-char-005.html
+    status: FAIL

--- a/css/css-text/white-space/META.yml
+++ b/css/css-text/white-space/META.yml
@@ -1,0 +1,64 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=197970
+  results:
+  - test: break-spaces-010.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: textarea-pre-wrap-012.html
+    status: FAIL
+  - test: textarea-pre-wrap-013.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: line-edge-white-space-collapse-001.html
+    status: FAIL
+  - test: line-edge-white-space-collapse-002.html
+    status: FAIL
+  - test: pre-wrap-014.html
+    status: FAIL
+  - test: tab-stop-threshold-002.html
+    status: FAIL
+  - test: tab-stop-threshold-004.html
+    status: FAIL
+  - test: tab-stop-threshold-006.html
+    status: FAIL
+  - test: text-space-collapse-discard-001.xht
+    status: FAIL
+  - test: text-space-collapse-preserve-breaks-001.xht
+    status: FAIL
+  - test: text-space-trim-trim-inner-001.xht
+    status: FAIL
+  - test: trailing-ideographic-space-001.html
+    status: FAIL
+  - test: trailing-ideographic-space-002.html
+    status: FAIL
+  - test: trailing-ideographic-space-003.html
+    status: FAIL
+  - test: trailing-ideographic-space-004.html
+    status: FAIL
+  - test: white-space-intrinsic-size-001.html
+    status: FAIL
+  - test: white-space-pre-wrap-trailing-spaces-002.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195345
+  results:
+  - test: break-spaces-before-first-char-003.html
+    status: FAIL
+  - test: break-spaces-before-first-char-006.html
+    status: FAIL
+  - test: break-spaces-before-first-char-013.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=197277
+  results:
+  - test: break-spaces-008.html
+    status: FAIL
+  - test: break-spaces-before-first-char-004.html
+    status: FAIL
+  - test: break-spaces-before-first-char-005.html
+    status: FAIL

--- a/css/css-text/word-break/META.yml
+++ b/css/css-text/word-break/META.yml
@@ -60,3 +60,70 @@ links:
     status: FAIL
   - test: word-break-break-all-027.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: word-break-break-all-004.html
+    status: FAIL
+  - test: word-break-break-all-007.html
+    status: FAIL
+  - test: word-break-break-all-008.html
+    status: FAIL
+  - test: word-break-keep-all-003.html
+    status: FAIL
+  - test: word-break-normal-bo-000.html
+    status: FAIL
+  - test: word-break-normal-lo-000.html
+    status: FAIL
+  - test: word-break-normal-my-000.html
+    status: FAIL
+  - test: word-break-normal-tdd-000.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: word-break-break-all-014.html
+    status: FAIL
+  - test: word-break-break-all-020.html
+    status: FAIL
+  - test: word-break-keep-all-005.html
+    status: FAIL
+  - test: word-break-keep-all-006.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195345
+  results:
+  - test: word-break-break-word-overflow-wrap-interactions.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=197277
+  results:
+  - test: word-break-break-all-017.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=197409
+  results:
+  - test: word-break-break-all-016.html
+    status: FAIL
+  - test: word-break-break-all-019.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=197411
+  results:
+  - test: word-break-break-all-018.html
+    status: FAIL
+  - test: word-break-break-all-021.html
+    status: FAIL
+  - test: word-break-break-all-022.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=197430
+  results:
+  - test: word-break-break-all-023.html
+    status: FAIL
+  - test: word-break-break-all-024.html
+    status: FAIL
+  - test: word-break-break-all-026.html
+    status: FAIL
+  - test: word-break-break-all-027.html
+    status: FAIL

--- a/css/css-text/word-break/META.yml
+++ b/css/css-text/word-break/META.yml
@@ -1,0 +1,62 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183258
+  results:
+  - test: word-break-break-all-004.html
+    status: FAIL
+  - test: word-break-break-all-006.html
+    status: FAIL
+  - test: word-break-break-all-008.html
+    status: FAIL
+  - test: word-break-keep-all-003.html
+    status: FAIL
+  - test: word-break-normal-my-000.html
+    status: FAIL
+  - test: word-break-normal-tdd-000.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: word-break-break-all-020.html
+    status: FAIL
+  - test: word-break-keep-all-005.html
+    status: FAIL
+  - test: word-break-keep-all-006.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195345
+  results:
+  - test: word-break-break-word-overflow-wrap-interactions.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=197277
+  results:
+  - test: word-break-break-all-017.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=197409
+  results:
+  - test: word-break-break-all-016.html
+    status: FAIL
+  - test: word-break-break-all-019.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=197411
+  results:
+  - test: word-break-break-all-018.html
+    status: FAIL
+  - test: word-break-break-all-021.html
+    status: FAIL
+  - test: word-break-break-all-022.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=197430
+  results:
+  - test: word-break-break-all-023.html
+    status: FAIL
+  - test: word-break-break-all-024.html
+    status: FAIL
+  - test: word-break-break-all-026.html
+    status: FAIL
+  - test: word-break-break-all-027.html
+    status: FAIL

--- a/css/css-text/writing-system/META.yml
+++ b/css/css-text/writing-system/META.yml
@@ -8,3 +8,14 @@ links:
     status: FAIL
   - test: writing-system-text-transform-001.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: writing-system-line-break-001.html
+    status: FAIL
+  - test: writing-system-line-break-002.html
+    status: FAIL
+  - test: writing-system-segment-break-001.html
+    status: FAIL
+  - test: writing-system-text-transform-001.html
+    status: FAIL

--- a/css/css-text/writing-system/META.yml
+++ b/css/css-text/writing-system/META.yml
@@ -1,0 +1,10 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=195275
+  results:
+  - test: writing-system-line-break-002.html
+    status: FAIL
+  - test: writing-system-segment-break-001.html
+    status: FAIL
+  - test: writing-system-text-transform-001.html
+    status: FAIL

--- a/css/css-ui/META.yml
+++ b/css/css-ui/META.yml
@@ -31,3 +31,35 @@ links:
     status: FAIL
   - test: outline-019.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=175287
+  results:
+  - test: box-sizing-014.html
+    status: FAIL
+  - test: box-sizing-015.html
+    status: FAIL
+  - test: box-sizing-016.html
+    status: FAIL
+  - test: box-sizing-018.html
+    status: FAIL
+  - test: box-sizing-019.html
+    status: FAIL
+  - test: box-sizing-024.html
+    status: FAIL
+  - test: box-sizing-025.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=175288
+  results:
+  - test: outline-005.html
+    status: FAIL
+  - test: outline-013.html
+    status: FAIL
+  - test: outline-014.html
+    status: FAIL
+  - test: outline-015.html
+    status: FAIL
+  - test: outline-016.html
+    status: FAIL
+  - test: outline-019.html
+    status: FAIL

--- a/css/css-ui/META.yml
+++ b/css/css-ui/META.yml
@@ -1,0 +1,33 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=175287
+  results:
+  - test: box-sizing-014.html
+    status: FAIL
+  - test: box-sizing-015.html
+    status: FAIL
+  - test: box-sizing-016.html
+    status: FAIL
+  - test: box-sizing-018.html
+    status: FAIL
+  - test: box-sizing-019.html
+    status: FAIL
+  - test: box-sizing-024.html
+    status: FAIL
+  - test: box-sizing-025.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=175288
+  results:
+  - test: outline-005.html
+    status: FAIL
+  - test: outline-013.html
+    status: FAIL
+  - test: outline-014.html
+    status: FAIL
+  - test: outline-015.html
+    status: FAIL
+  - test: outline-016.html
+    status: FAIL
+  - test: outline-019.html
+    status: FAIL

--- a/css/css-values/META.yml
+++ b/css/css-values/META.yml
@@ -3,3 +3,114 @@ links:
   results:
   - test: ch-unit-017.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1470075
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203320
+  results:
+  - test: percentage-rem-low.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203322
+  results:
+  - test: attr-color-invalid-cast.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203323
+  results:
+  - test: attr-color-valid.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203324
+  results:
+  - test: attr-in-max.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203325
+  results:
+  - test: attr-invalid-type-008.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203326
+  results:
+  - test: attr-length-invalid-cast.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203327
+  results:
+  - test: attr-length-valid-zero-nofallback.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203328
+  results:
+  - test: attr-length-valid-zero.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203329
+  results:
+  - test: attr-length-valid.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203330
+  results:
+  - test: attr-px-invalid-cast.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203331
+  results:
+  - test: attr-px-valid.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203333
+  results:
+  - test: ch-unit-002.html
+    status: FAIL
+  - test: ch-unit-003.html
+    status: FAIL
+  - test: ch-unit-004.html
+    status: FAIL
+  - test: ch-unit-010.html
+    status: FAIL
+  - test: ch-unit-011.html
+    status: FAIL
+  - test: ch-unit-012.html
+    status: FAIL
+  - test: ch-unit-013.html
+    status: FAIL
+  - test: ch-unit-014.html
+    status: FAIL
+  - test: ch-unit-015.html
+    status: FAIL
+  - test: ch-unit-018.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203334
+  results:
+  - test: ic-unit-001.html
+    status: FAIL
+  - test: ic-unit-002.html
+    status: FAIL
+  - test: ic-unit-003.html
+    status: FAIL
+  - test: ic-unit-004.html
+    status: FAIL
+  - test: ic-unit-008.html
+    status: FAIL
+  - test: ic-unit-009.html
+    status: FAIL
+  - test: ic-unit-010.html
+    status: FAIL
+  - test: ic-unit-011.html
+    status: FAIL
+  - test: ic-unit-012.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203336
+  results:
+  - test: lh-unit-001.html
+    status: FAIL
+  - test: lh-unit-002.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203337
+  results:
+  - test: vh-support-atviewport.html
+    status: FAIL

--- a/css/css-values/META.yml
+++ b/css/css-values/META.yml
@@ -114,3 +114,102 @@ links:
   results:
   - test: vh-support-atviewport.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203320
+  results:
+  - test: percentage-rem-low.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203322
+  results:
+  - test: attr-color-invalid-cast.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203323
+  results:
+  - test: attr-color-valid.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203324
+  results:
+  - test: attr-in-max.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203325
+  results:
+  - test: attr-invalid-type-008.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203326
+  results:
+  - test: attr-length-invalid-cast.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203327
+  results:
+  - test: attr-length-valid-zero-nofallback.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203328
+  results:
+  - test: attr-length-valid-zero.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203329
+  results:
+  - test: attr-length-valid.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203330
+  results:
+  - test: attr-px-invalid-cast.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203331
+  results:
+  - test: attr-px-valid.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203333
+  results:
+  - test: ch-unit-013.html
+    status: FAIL
+  - test: ch-unit-014.html
+    status: FAIL
+  - test: ch-unit-015.html
+    status: FAIL
+  - test: ch-unit-018.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203334
+  results:
+  - test: ic-unit-001.html
+    status: FAIL
+  - test: ic-unit-002.html
+    status: FAIL
+  - test: ic-unit-003.html
+    status: FAIL
+  - test: ic-unit-004.html
+    status: FAIL
+  - test: ic-unit-008.html
+    status: FAIL
+  - test: ic-unit-009.html
+    status: FAIL
+  - test: ic-unit-010.html
+    status: FAIL
+  - test: ic-unit-011.html
+    status: FAIL
+  - test: ic-unit-012.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203336
+  results:
+  - test: lh-unit-001.html
+    status: FAIL
+  - test: lh-unit-002.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203337
+  results:
+  - test: vh-support-atviewport.html
+    status: FAIL

--- a/css/cssom-view/META.yml
+++ b/css/cssom-view/META.yml
@@ -11,3 +11,10 @@ links:
   - subtest: BODY element scroll-behavior should not propagate to viewport
     test: scroll-behavior-smooth.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1556685
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=182292
+  results:
+  - test: scrollingElement-quirks-dynamic-001.html
+    status: FAIL
+  - test: scrollingElement-quirks-dynamic-002.html
+    status: FAIL

--- a/css/cssom-view/META.yml
+++ b/css/cssom-view/META.yml
@@ -18,3 +18,10 @@ links:
     status: FAIL
   - test: scrollingElement-quirks-dynamic-002.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=182292
+  results:
+  - test: scrollingElement-quirks-dynamic-001.html
+    status: FAIL
+  - test: scrollingElement-quirks-dynamic-002.html
+    status: FAIL

--- a/css/mediaqueries/META.yml
+++ b/css/mediaqueries/META.yml
@@ -1,0 +1,8 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=156684
+  results:
+  - test: mq-calc-005.html
+    status: FAIL
+  - test: relative-units-001.html
+    status: FAIL

--- a/css/mediaqueries/META.yml
+++ b/css/mediaqueries/META.yml
@@ -6,3 +6,10 @@ links:
     status: FAIL
   - test: relative-units-001.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=156684
+  results:
+  - test: mq-calc-005.html
+    status: FAIL
+  - test: relative-units-001.html
+    status: FAIL

--- a/css/selectors/META.yml
+++ b/css/selectors/META.yml
@@ -18,3 +18,10 @@ links:
     status: FAIL
   - test: selectors-dir-selector-rtl-001.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=64861
+  results:
+  - test: selectors-dir-selector-ltr-001.html
+    status: FAIL
+  - test: selectors-dir-selector-rtl-001.html
+    status: FAIL

--- a/css/selectors/META.yml
+++ b/css/selectors/META.yml
@@ -11,3 +11,10 @@ links:
   results:
   - test: selector-placeholder-shown-type-change-001.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1401657
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=64861
+  results:
+  - test: selectors-dir-selector-ltr-001.html
+    status: FAIL
+  - test: selectors-dir-selector-rtl-001.html
+    status: FAIL


### PR DESCRIPTION
This PR adds test-result metadata for expected failures for `css/` tests for products `safari` and `webkitgtk`.

This entries have been auto-generated with a script that I wrote that parses the [WebKit's TestExpectations](https://trac.webkit.org/wiki/TestExpectations) files and looks for failures already reported (related to the imported WPT tests available as layout tests in WebKit).
This script then queries wpt.fyi to check the status of this tests on the last WPT run for the specified browser product, and for the tests that are failing on wpt.fyi the corresponding metadata entries are generated using the webkit.org bugzilla numbers from WebKit's TestExpectation files.

//cc @stephenmcgruer  @foolip 