### PR TITLE
Check Links Key Duplication

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -36,18 +36,19 @@ func TestParseMetadata(t *testing.T) {
 			}
 			err = yaml.Unmarshal(data, &metadata)
 			assert.Nil(t, err)
-			if strings.Contains(string(data), "links:") {
-				assert.Greater(t, len(metadata.Links), 0)
-				linkMap := make(map[string]string)
-				for _, link := range metadata.Links {
-					assert.Greater(t, len(link.Results), 0)
-					assert.Greater(t, len(link.URL), 0)
-					checkDuplicationAcrossLinks(t, link, linkMap)
-					resultSet := mapset.NewSet()
-					for _, result := range link.Results {
-						assert.Greater(t, len(result.TestPath), 0)
-						checkDuplicationWithinResults(t, result, resultSet)
-					}
+
+			linkCount := strings.Count(string(data), "links:")
+			assert.Equal(t, linkCount, 1, "YML file should only contain one `links:` key")
+			assert.Greater(t, len(metadata.Links), 0)
+			linkMap := make(map[string]string)
+			for _, link := range metadata.Links {
+				assert.Greater(t, len(link.Results), 0)
+				assert.Greater(t, len(link.URL), 0)
+				checkDuplicationAcrossLinks(t, link, linkMap)
+				resultSet := mapset.NewSet()
+				for _, result := range link.Results {
+					assert.Greater(t, len(result.TestPath), 0)
+					checkDuplicationWithinResults(t, result, resultSet)
 				}
 			}
 		})

--- a/parse_test.go
+++ b/parse_test.go
@@ -38,7 +38,7 @@ func TestParseMetadata(t *testing.T) {
 			assert.Nil(t, err)
 
 			linkCount := strings.Count(string(data), "links:")
-			assert.Equal(t, linkCount, 1, "YML file should only contain one `links:` key")
+			assert.Equal(t, linkCount, 1, "YML file should contain exactly one links: key")
 			assert.Greater(t, len(metadata.Links), 0)
 			linkMap := make(map[string]string)
 			for _, link := range metadata.Links {


### PR DESCRIPTION
Avoid having multiple `links:` keys in the metadata files. This testing rule should be changed once a new type of keys is added, e.g. flaky.