### PR TITLE
Add metadata with safari and webkitgtk expected failures for !css/

### DIFF
--- a/encoding/META.yml
+++ b/encoding/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=179881
+  results:
+  - test: eof-shift_jis.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=179881
+  results:
+  - test: eof-shift_jis.html
+    status: FAIL

--- a/html/semantics/embedded-content/the-video-element/META.yml
+++ b/html/semantics/embedded-content/the-video-element/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=148856
+  results:
+  - test: video_initially_paused.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=148856
+  results:
+  - test: video_initially_paused.html
+    status: FAIL

--- a/html/semantics/grouping-content/the-li-element/META.yml
+++ b/html/semantics/grouping-content/the-li-element/META.yml
@@ -1,0 +1,15 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=168175
+  results:
+  - test: grouping-li-reftest-list-owner-menu.html
+    status: FAIL
+  - test: grouping-li-reftest-list-owner-skip-no-boxes.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=168175
+  results:
+  - test: grouping-li-reftest-list-owner-menu.html
+    status: FAIL
+  - test: grouping-li-reftest-list-owner-skip-no-boxes.html
+    status: FAIL

--- a/mathml/presentation-markup/fractions/META.yml
+++ b/mathml/presentation-markup/fractions/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=194952
+  results:
+  - test: frac-bar-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=194952
+  results:
+  - test: frac-bar-001.html
+    status: FAIL

--- a/mathml/relations/text-and-math/META.yml
+++ b/mathml/relations/text-and-math/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=150394
+  results:
+  - test: use-typo-metrics-1.html
+    status: FAIL

--- a/media-source/META.yml
+++ b/media-source/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=167108
+  results:
+  - test: mediasource-sourcebuffer-mode-timestamps.html
+    status: TIMEOUT
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203078
+  results:
+  - test: mediasource-seek-beyond-duration.html
+    status: TIMEOUT

--- a/pointerevents/META.yml
+++ b/pointerevents/META.yml
@@ -1,0 +1,22 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=204115
+  results:
+  - test: pointerevent_change-touch-action-onpointerdown_touch.html
+    status: ERROR
+  - test: pointerevent_pointercancel_touch.html
+    status: ERROR
+  - test: pointerevent_pointerleave_after_pointercancel_touch.html
+    status: ERROR
+  - test: pointerevent_pointerout_after_pointercancel_touch.html
+    status: ERROR
+  - test: pointerevent_pointerout_pen.html
+    status: ERROR
+  - test: pointerevent_releasepointercapture_onpointercancel_touch.html
+    status: ERROR
+  - test: pointerevent_touch-action-auto-css_touch.html
+    status: ERROR
+  - test: pointerevent_touch-action-inherit_highest-parent-none_touch.html
+    status: ERROR
+  - test: pointerevent_touch-action-pan-x-pan-y_touch.html
+    status: ERROR

--- a/shadow-dom/META.yml
+++ b/shadow-dom/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202495
+  results:
+  - test: directionality-002.tentative.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=202495
+  results:
+  - test: directionality-002.tentative.html
+    status: FAIL

--- a/svg/extensibility/foreignObject/META.yml
+++ b/svg/extensibility/foreignObject/META.yml
@@ -1,0 +1,33 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=201110
+  results:
+  - test: position-svg-root-in-foreign-object.html
+    status: FAIL
+  - test: stacking-context.html
+    status: FAIL
+  - test: will-change-in-transformed-foreign-object.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=201946
+  results:
+  - test: composited-inside-object.html
+    status: FAIL
+  - test: compositing-backface-visibility.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=201110
+  results:
+  - test: position-svg-root-in-foreign-object.html
+    status: FAIL
+  - test: stacking-context.html
+    status: FAIL
+  - test: will-change-in-transformed-foreign-object.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=201946
+  results:
+  - test: composited-inside-object.html
+    status: FAIL
+  - test: compositing-backface-visibility.html
+    status: FAIL

--- a/svg/linking/reftests/META.yml
+++ b/svg/linking/reftests/META.yml
@@ -1,0 +1,21 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=173154
+  results:
+  - test: use-keyframes.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=201992
+  results:
+  - test: href-filter-element.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=173154
+  results:
+  - test: use-keyframes.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=201992
+  results:
+  - test: href-filter-element.html
+    status: FAIL

--- a/svg/render/reftests/META.yml
+++ b/svg/render/reftests/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=201918
+  results:
+  - test: change-sync-for-nested-use.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=201918
+  results:
+  - test: change-sync-for-nested-use.html
+    status: FAIL


### PR DESCRIPTION
This PR its like #45 but adding the remaining available information (for all tests that are not under css/). It adds the info for products `safari` and `webkitgtk`.

This (like #45) is only adding the tests that don't have subtests and are marked on the WebKit TestExpectations as failing always (non-flaky) or skipped. 

There are many others (like 2x this volume at least) that are marked as flaky on the WebKit TestExpectation files. Not sure how to handle this flaky tests. For now the script avoid to parse those. One idea is to check the last X runs on wpt.fyi for $browser and only add metadata for those that don't are flaky on wpt.fyi. That can be also interesting info for WebKit since that would indicate maybe a problem in how WebKit runs the tests. I would like to handle those in future improvements of the script.

Another thing the script is still not handling is the tests that have subtests. It's simply skipping to add those. I will try to handle that in a next iteration.

For now let's import only the ones not marked as flaky and without subtests.

//cc @stephenmcgruer  @foolip 