### PR TITLE
Add Support for Wildcards in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ Where
   - `{browser-name}[-{browser-version}[-{os}[-{os-version}]]]`
   - e.g. `chrome`, `safari-12`, or `firefox-63.0-linux`
 - If omitted, the link will apply to all products in the directory.
-- Test path is a filename, which is relative to the current directory. If it is *, the link will apply to all tests in the current directory and its subdirectories.
+- Test path is a filename, which is relative to the current directory. If it is `*`, the link will apply to all tests in the current directory and its subdirectories.
 - Test result status is a status as defined in the wpt.fyi codebase.

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ Where
   - `{browser-name}[-{browser-version}[-{os}[-{os-version}]]]`
   - e.g. `chrome`, `safari-12`, or `firefox-63.0-linux`
 - If omitted, the link will apply to all products in the directory.
-- Test path is relative to the current directory, so will typically be just a filename.
+- Test path is a filename, which is relative to the current directory. If it is *, the link will apply to all tests in the current directory and its subdirectories.
 - Test result status is a status as defined in the wpt.fyi codebase.


### PR DESCRIPTION
A fix for https://github.com/web-platform-tests/wpt-metadata/issues/49. 

Note that as a result of this change, one test could potentially have two corresponding URLs - one in the `link` node with a wildcard in the parent directories of this test, and one in the current directory.