### PR TITLE
Add more metadata with Safari and WebKitGTK expected failures.

### DIFF
--- a/animation-worklet/META.yml
+++ b/animation-worklet/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=199156
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=199156
+  results:
+  - test: "*"

--- a/css/css-conditional/META.yml
+++ b/css/css-conditional/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=200838
+  results:
+  - test: idlharness.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=200838
+  results:
+  - test: idlharness.html
+    status: FAIL

--- a/css/css-fonts/META.yml
+++ b/css/css-fonts/META.yml
@@ -10,3 +10,17 @@ links:
       status: FAIL
     - test: font-synthesis-04.html
       status: FAIL
+  - product: safari
+    url: https://bugs.webkit.org/show_bug.cgi?id=15257
+    results:
+    - test: font-size-adjust-002.html
+      status: FAIL
+    - test: font-size-adjust-005.xht
+      status: FAIL
+  - product: webkitgtk
+    url: https://bugs.webkit.org/show_bug.cgi?id=15257
+    results:
+    - test: font-size-adjust-002.html
+      status: FAIL
+    - test: font-size-adjust-005.xht
+      status: FAIL

--- a/css/css-fonts/animations/META.yml
+++ b/css/css-fonts/animations/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=15257
+  results:
+  - test: font-size-adjust-interpolation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=15257
+  results:
+  - test: font-size-adjust-interpolation.html
+    status: FAIL

--- a/css/css-fonts/font-display/META.yml
+++ b/css/css-fonts/font-display/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=167332
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=167332
+  results:
+  - test: "*"

--- a/css/css-fonts/parsing/META.yml
+++ b/css/css-fonts/parsing/META.yml
@@ -1,0 +1,15 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=15257
+  results:
+  - test: font-size-adjust-computed.html
+    status: FAIL
+  - test: font-size-adjust-valid.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=15257
+  results:
+  - test: font-size-adjust-computed.html
+    status: FAIL
+  - test: font-size-adjust-valid.html
+    status: FAIL

--- a/css/css-paint-api/META.yml
+++ b/css/css-paint-api/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=190217
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=190217
+  results:
+  - test: "*"

--- a/css/css-properties-values-api/META.yml
+++ b/css/css-properties-values-api/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=189692
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=189692
+  results:
+  - test: "*"

--- a/css/css-transforms/META.yml
+++ b/css/css-transforms/META.yml
@@ -1,0 +1,83 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=206514
+  results:
+  - test: perspective-origin-001.html
+    status: FAIL
+  - test: perspective-origin-002.html
+    status: FAIL
+  - test: perspective-origin-003.html
+    status: FAIL
+  - test: perspective-origin-004.html
+    status: FAIL
+  - test: perspective-origin-005.html
+    status: FAIL
+  - test: perspective-origin-006.html
+    status: FAIL
+  - test: perspective-origin-x.html
+    status: FAIL
+  - test: perspective-origin-xy.html
+    status: FAIL
+  - test: perspective-translateZ-0.html
+    status: FAIL
+  - test: perspective-translateZ-negative.html
+    status: FAIL
+  - test: perspective-translateZ-positive.html
+    status: FAIL
+  - test: text-perspective-001.html
+    status: FAIL
+  - test: transform-3d-rotateY-stair-above-001.xht
+    status: FAIL
+  - test: transform3d-matrix3d-005.html
+    status: FAIL
+  - test: transform3d-perspective-006.html
+    status: FAIL
+  - test: transform3d-preserve3d-011.html
+    status: FAIL
+  - test: transform3d-scale-004.html
+    status: FAIL
+  - test: transform3d-sorting-001.html
+    status: FAIL
+  - test: transofrmed-preserve-3d-1.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206514
+  results:
+  - test: perspective-origin-001.html
+    status: FAIL
+  - test: perspective-origin-002.html
+    status: FAIL
+  - test: perspective-origin-003.html
+    status: FAIL
+  - test: perspective-origin-004.html
+    status: FAIL
+  - test: perspective-origin-005.html
+    status: FAIL
+  - test: perspective-origin-006.html
+    status: FAIL
+  - test: perspective-origin-x.html
+    status: FAIL
+  - test: perspective-origin-xy.html
+    status: FAIL
+  - test: perspective-translateZ-0.html
+    status: FAIL
+  - test: perspective-translateZ-negative.html
+    status: FAIL
+  - test: perspective-translateZ-positive.html
+    status: FAIL
+  - test: text-perspective-001.html
+    status: FAIL
+  - test: transform-3d-rotateY-stair-above-001.xht
+    status: FAIL
+  - test: transform3d-matrix3d-005.html
+    status: FAIL
+  - test: transform3d-perspective-006.html
+    status: FAIL
+  - test: transform3d-preserve3d-011.html
+    status: FAIL
+  - test: transform3d-scale-004.html
+    status: FAIL
+  - test: transform3d-sorting-001.html
+    status: FAIL
+  - test: transofrmed-preserve-3d-1.html
+    status: FAIL

--- a/css/css-transforms/animation/META.yml
+++ b/css/css-transforms/animation/META.yml
@@ -1,0 +1,107 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=178117
+  results:
+  - test: list-interpolation.html
+    status: FAIL
+  - test: matrix-interpolation.html
+    status: FAIL
+  - test: perspective-composition.html
+    status: FAIL
+  - test: perspective-interpolation.html
+    status: FAIL
+  - test: perspective-origin-interpolation.html
+    status: FAIL
+  - test: rotate-composition.html
+    status: FAIL
+  - test: rotate-interpolation.html
+    status: FAIL
+  - test: scale-composition.html
+    status: FAIL
+  - test: scale-interpolation.html
+    status: FAIL
+  - test: transform-composition.html
+    status: FAIL
+  - test: transform-interpolation-001.html
+    status: FAIL
+  - test: transform-interpolation-002.html
+    status: FAIL
+  - test: transform-interpolation-003.html
+    status: FAIL
+  - test: transform-interpolation-004.html
+    status: FAIL
+  - test: transform-interpolation-005.html
+    status: FAIL
+  - test: transform-interpolation-006.html
+    status: FAIL
+  - test: transform-matrix-composition.html
+    status: FAIL
+  - test: transform-origin-interpolation.html
+    status: FAIL
+  - test: transform-perspective-composition.html
+    status: FAIL
+  - test: transform-rotate-composition.html
+    status: FAIL
+  - test: transform-scale-composition.html
+    status: FAIL
+  - test: transform-skew-composition.html
+    status: FAIL
+  - test: transform-translate-composition.html
+    status: FAIL
+  - test: translate-composition.html
+    status: FAIL
+  - test: translate-interpolation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=178117
+  results:
+  - test: list-interpolation.html
+    status: FAIL
+  - test: matrix-interpolation.html
+    status: FAIL
+  - test: perspective-composition.html
+    status: FAIL
+  - test: perspective-interpolation.html
+    status: FAIL
+  - test: perspective-origin-interpolation.html
+    status: FAIL
+  - test: rotate-composition.html
+    status: FAIL
+  - test: rotate-interpolation.html
+    status: FAIL
+  - test: scale-composition.html
+    status: FAIL
+  - test: scale-interpolation.html
+    status: FAIL
+  - test: transform-composition.html
+    status: FAIL
+  - test: transform-interpolation-001.html
+    status: FAIL
+  - test: transform-interpolation-002.html
+    status: FAIL
+  - test: transform-interpolation-003.html
+    status: FAIL
+  - test: transform-interpolation-004.html
+    status: FAIL
+  - test: transform-interpolation-005.html
+    status: FAIL
+  - test: transform-interpolation-006.html
+    status: FAIL
+  - test: transform-matrix-composition.html
+    status: FAIL
+  - test: transform-origin-interpolation.html
+    status: FAIL
+  - test: transform-perspective-composition.html
+    status: FAIL
+  - test: transform-rotate-composition.html
+    status: FAIL
+  - test: transform-scale-composition.html
+    status: FAIL
+  - test: transform-skew-composition.html
+    status: FAIL
+  - test: transform-translate-composition.html
+    status: FAIL
+  - test: translate-composition.html
+    status: FAIL
+  - test: translate-interpolation.html
+    status: FAIL

--- a/css/css-typed-om/META.yml
+++ b/css/css-typed-om/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=175733
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=175733
+  results:
+  - test: "*"

--- a/css/geometry/META.yml
+++ b/css/geometry/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=153675
+  results:
+  - test: WebKitCSSMatrix.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=153675
+  results:
+  - test: WebKitCSSMatrix.html
+    status: FAIL

--- a/css/motion/META.yml
+++ b/css/motion/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=139127
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=139127
+  results:
+  - test: "*"

--- a/feature-policy/META.yml
+++ b/feature-policy/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183300
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183300
+  results:
+  - test: "*"

--- a/reporting/META.yml
+++ b/reporting/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=189365
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=189365
+  results:
+  - test: "*"

--- a/worklets/META.yml
+++ b/worklets/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=192328
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=192328
+  results:
+  - test: "*"


### PR DESCRIPTION
* This adds metadata about mostly css/ tests.

* Some of the metadata is about features still not implemented,
  so the key 'tests: *' is used to assign to whole directory to
  the WebKit bug about the missing implementation.

//cc @stephenmcgruer @foolip 