### PR TITLE
Fixup css/css-transform/META.yml after file was moved

### DIFF
--- a/css/css-transforms/META.yml
+++ b/css/css-transforms/META.yml
@@ -38,7 +38,7 @@ links:
     status: FAIL
   - test: transform3d-sorting-001.html
     status: FAIL
-  - test: transofrmed-preserve-3d-1.html
+  - test: transformed-preserve-3d-1.html
     status: FAIL
 - product: webkitgtk
   url: https://bugs.webkit.org/show_bug.cgi?id=206514
@@ -79,5 +79,5 @@ links:
     status: FAIL
   - test: transform3d-sorting-001.html
     status: FAIL
-  - test: transofrmed-preserve-3d-1.html
+  - test: transformed-preserve-3d-1.html
     status: FAIL


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/21394 corrected the
filename of this file, but I then (not-thinking) merged the now out of
date metadata PR.