### PR TITLE
Add more metadata of expected failures for Safari and WebKitGTK

### DIFF
--- a/custom-elements/reactions/META.yml
+++ b/custom-elements/reactions/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://github.com/web-platform-tests/wpt/issues/21854
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://github.com/web-platform-tests/wpt/issues/21854
+  results:
+  - test: "*"

--- a/custom-elements/reactions/META.yml
+++ b/custom-elements/reactions/META.yml
@@ -1,9 +1,9 @@
 links:
 - product: safari
-  url: https://github.com/web-platform-tests/wpt/issues/21854
+  url: https://bugs.webkit.org/show_bug.cgi?id=182671
   results:
   - test: "*"
 - product: webkitgtk
-  url: https://github.com/web-platform-tests/wpt/issues/21854
+  url: https://bugs.webkit.org/show_bug.cgi?id=182671
   results:
   - test: "*"

--- a/push-api/META.yml
+++ b/push-api/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=182566
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=182566
+  results:
+  - test: "*"

--- a/selection/META.yml
+++ b/selection/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=145212
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=145212
+  results:
+  - test: "*"

--- a/web-animations/animation-model/animation-types/META.yml
+++ b/web-animations/animation-model/animation-types/META.yml
@@ -5,3 +5,33 @@ links:
       function'
     test: interpolation-per-property.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1345709
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186485
+  results:
+  - test: accumulation-per-property.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186486
+  results:
+  - test: addition-per-property.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186488
+  results:
+  - test: interpolation-per-property.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186485
+  results:
+  - test: accumulation-per-property.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186486
+  results:
+  - test: addition-per-property.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186488
+  results:
+  - test: interpolation-per-property.html
+    status: FAIL

--- a/web-animations/animation-model/combining-effects/META.yml
+++ b/web-animations/animation-model/combining-effects/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186489
+  results:
+  - test: effect-composition.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186489
+  results:
+  - test: effect-composition.html
+    status: FAIL

--- a/web-animations/animation-model/keyframe-effects/META.yml
+++ b/web-animations/animation-model/keyframe-effects/META.yml
@@ -1,0 +1,31 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186490
+  results:
+  - test: effect-value-context.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186491
+  results:
+  - test: effect-value-iteration-composite-operation.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186493
+  results:
+  - test: effect-value-transformed-distance.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186490
+  results:
+  - test: effect-value-context.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186491
+  results:
+  - test: effect-value-iteration-composite-operation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186493
+  results:
+  - test: effect-value-transformed-distance.html
+    status: FAIL

--- a/web-animations/interfaces/Animatable/META.yml
+++ b/web-animations/interfaces/Animatable/META.yml
@@ -1,0 +1,21 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186494
+  results:
+  - test: animate-no-browsing-context.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186495
+  results:
+  - test: animate.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186494
+  results:
+  - test: animate-no-browsing-context.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186495
+  results:
+  - test: animate.html
+    status: FAIL

--- a/web-animations/interfaces/KeyframeEffect/META.yml
+++ b/web-animations/interfaces/KeyframeEffect/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=186500
+  results:
+  - test: iterationComposite.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186500
+  results:
+  - test: iterationComposite.html
+    status: FAIL


### PR DESCRIPTION
* This adds metadata for `custom-elements/`, `push-api/`, `selection/ ` and `web-animations/`