### PR TITLE
Add metadata with css-grid expected failures for Safari and WebKitGTK.

### DIFF
--- a/css/css-grid/abspos/META.yml
+++ b/css/css-grid/abspos/META.yml
@@ -17,3 +17,87 @@ links:
     status: FAIL
   - test: grid-item-absolute-positioning-dynamic-001.html
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209460
+  results:
+  - test: descendant-static-position-001.html
+    status: FAIL
+  - test: descendant-static-position-002.html
+    status: FAIL
+  - test: descendant-static-position-003.html
+    status: FAIL
+  - test: descendant-static-position-004.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=189513
+  results:
+  - test: orthogonal-positioned-grid-descendants-001.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-002.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-003.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-004.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-005.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-007.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-010.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-013.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-015.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-016.html
+    status: FAIL
+  - test: positioned-grid-descendants-007.html
+    status: FAIL
+  - test: positioned-grid-descendants-012.html
+    status: FAIL
+  - test: positioned-grid-descendants-014.html
+    status: FAIL
+  - test: positioned-grid-descendants-016.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209460
+  results:
+  - test: descendant-static-position-001.html
+    status: FAIL
+  - test: descendant-static-position-002.html
+    status: FAIL
+  - test: descendant-static-position-003.html
+    status: FAIL
+  - test: descendant-static-position-004.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=189513
+  results:
+  - test: orthogonal-positioned-grid-descendants-001.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-002.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-003.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-004.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-005.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-007.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-010.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-013.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-015.html
+    status: FAIL
+  - test: orthogonal-positioned-grid-descendants-016.html
+    status: FAIL
+  - test: positioned-grid-descendants-007.html
+    status: FAIL
+  - test: positioned-grid-descendants-012.html
+    status: FAIL
+  - test: positioned-grid-descendants-014.html
+    status: FAIL
+  - test: positioned-grid-descendants-016.html
+    status: FAIL

--- a/css/css-grid/alignment/META.yml
+++ b/css/css-grid/alignment/META.yml
@@ -28,3 +28,25 @@ links:
   - subtest: .wrapper 2
     test: grid-container-baseline-001.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1623963
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=180633
+  results:
+  - test: grid-self-alignment-non-static-positioned-items-009.html
+    status: FAIL
+  - test: grid-self-alignment-non-static-positioned-items-010.html
+    status: FAIL
+  - test: grid-self-alignment-non-static-positioned-items-011.html
+    status: FAIL
+  - test: grid-self-alignment-non-static-positioned-items-012.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=180633
+  results:
+  - test: grid-self-alignment-non-static-positioned-items-009.html
+    status: FAIL
+  - test: grid-self-alignment-non-static-positioned-items-010.html
+    status: FAIL
+  - test: grid-self-alignment-non-static-positioned-items-011.html
+    status: FAIL
+  - test: grid-self-alignment-non-static-positioned-items-012.html
+    status: FAIL

--- a/css/css-grid/animation/META.yml
+++ b/css/css-grid/animation/META.yml
@@ -1,0 +1,23 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=204580
+  results:
+  - test: grid-template-columns-001.html
+    status: FAIL
+  - test: grid-template-columns-interpolation.html
+    status: FAIL
+  - test: grid-template-rows-001.html
+    status: FAIL
+  - test: grid-template-rows-interpolation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=204580
+  results:
+  - test: grid-template-columns-001.html
+    status: FAIL
+  - test: grid-template-columns-interpolation.html
+    status: FAIL
+  - test: grid-template-rows-001.html
+    status: FAIL
+  - test: grid-template-rows-interpolation.html
+    status: FAIL

--- a/css/css-grid/grid-items/META.yml
+++ b/css/css-grid/grid-items/META.yml
@@ -53,3 +53,101 @@ links:
   results:
   - test: explicitly-sized-grid-item-as-table.html
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209461
+  results:
+  - test: grid-item-dynamic-min-contribution-001.html
+    status: FAIL
+  - test: grid-items-percentage-margins-003.html
+    status: FAIL
+  - test: grid-items-percentage-margins-004.html
+    status: FAIL
+  - test: grid-items-percentage-margins-005.html
+    status: FAIL
+  - test: grid-items-percentage-margins-006.html
+    status: FAIL
+  - test: grid-items-percentage-margins-007.html
+    status: FAIL
+  - test: grid-items-percentage-margins-008.html
+    status: FAIL
+  - test: grid-items-percentage-margins-009.html
+    status: FAIL
+  - test: grid-items-percentage-margins-010.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-002.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-005.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-006.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-009.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-010.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-vertical-lr-002.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-vertical-rl-002.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209650
+  results:
+  - test: grid-item-percentage-sizes-001.html
+    status: FAIL
+  - test: grid-item-percentage-sizes-002.html
+    status: FAIL
+  - test: grid-item-percentage-sizes-003.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209651
+  results:
+  - test: grid-item-min-auto-size-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209461
+  results:
+  - test: grid-item-dynamic-min-contribution-001.html
+    status: FAIL
+  - test: grid-items-percentage-margins-003.html
+    status: FAIL
+  - test: grid-items-percentage-margins-004.html
+    status: FAIL
+  - test: grid-items-percentage-margins-005.html
+    status: FAIL
+  - test: grid-items-percentage-margins-006.html
+    status: FAIL
+  - test: grid-items-percentage-margins-007.html
+    status: FAIL
+  - test: grid-items-percentage-margins-008.html
+    status: FAIL
+  - test: grid-items-percentage-margins-009.html
+    status: FAIL
+  - test: grid-items-percentage-margins-010.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-002.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-005.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-006.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-009.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-010.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-vertical-lr-002.html
+    status: FAIL
+  - test: grid-items-percentage-paddings-vertical-rl-002.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209650
+  results:
+  - test: grid-item-percentage-sizes-001.html
+    status: FAIL
+  - test: grid-item-percentage-sizes-002.html
+    status: FAIL
+  - test: grid-item-percentage-sizes-003.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209651
+  results:
+  - test: grid-item-min-auto-size-001.html
+    status: FAIL

--- a/css/css-grid/grid-model/META.yml
+++ b/css/css-grid/grid-model/META.yml
@@ -9,3 +9,23 @@ links:
   results:
   - test: grid-container-ignores-first-letter-002.html
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209652
+  results:
+  - test: grid-box-sizing-001.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209656
+  results:
+  - test: grid-button-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209652
+  results:
+  - test: grid-box-sizing-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209656
+  results:
+  - test: grid-button-001.html
+    status: FAIL

--- a/css/css-grid/parsing/META.yml
+++ b/css/css-grid/parsing/META.yml
@@ -1,0 +1,19 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=204611
+  results:
+  - test: grid-area-shorthand.html
+    status: FAIL
+  - test: grid-shorthand.html
+    status: FAIL
+  - test: grid-template-shorthand.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=204611
+  results:
+  - test: grid-area-shorthand.html
+    status: FAIL
+  - test: grid-shorthand.html
+    status: FAIL
+  - test: grid-template-shorthand.html
+    status: FAIL

--- a/css/css-grid/subgrid/META.yml
+++ b/css/css-grid/subgrid/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202115
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=202115
+  results:
+  - test: "*"

--- a/html/rendering/widgets/button-layout/META.yml
+++ b/html/rendering/widgets/button-layout/META.yml
@@ -1,0 +1,15 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209656
+  results:
+  - test: flex.html
+    status: FAIL
+  - test: grid.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209656
+  results:
+  - test: flex.html
+    status: FAIL
+  - test: grid.html
+    status: FAIL

--- a/html/semantics/forms/the-input-element/META.yml
+++ b/html/semantics/forms/the-input-element/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=119175
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=119175
+  results:
+  - test: "*"


### PR DESCRIPTION
This adds metadata mostly for css-grid related expected failures on Safari and WebKitGTK, but there are also a few updates for html/