### PR TITLE
Fix automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
+        # https://github.com/pascalgn/automerge-action#configuration
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: ""
           MERGE_FORKS: false
           MERGE_FILTER_AUTHOR: "wptfyibot"


### PR DESCRIPTION
By default, only PRs with the "automerge" label will be auto-merged.

Fixes #125 