### PR TITLE
Add metadata with css-flexbox expected failures for Safari and WebKitGTK

### DIFF
--- a/css/css-contain/META.yml
+++ b/css/css-contain/META.yml
@@ -22,3 +22,11 @@ links:
   results:
   - test: contain-layout-005.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1554327
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=172026
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=172026
+  results:
+  - test: "*"

--- a/css/css-flexbox/META.yml
+++ b/css/css-flexbox/META.yml
@@ -9,3 +9,127 @@ links:
   results:
   - test: flex-minimum-width-flex-items-004.xht
   - test: flex-minimum-width-flex-items-006.xht
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209871
+  results:
+  - test: align-content-wrap-001.html
+    status: FAIL
+  - test: align-content-wrap-002.html
+    status: FAIL
+  - test: align-content-wrap-003.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210077
+  results:
+  - test: flex-aspect-ratio-img-column-010.html
+    status: FAIL
+  - test: flex-basis-010.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=172026
+  results:
+  - test: flex-item-contains-strict.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210088
+  results:
+  - test: flex-minimum-height-flex-items-010.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210089
+  results:
+  - test: flex-minimum-height-flex-items-011.xht
+    status: FAIL
+  - test: flex-minimum-height-flex-items-013.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=185771
+  results:
+  - test: hittest-overlapping-margin.html
+    status: FAIL
+  - test: hittest-overlapping-order.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210103
+  results:
+  - test: item-with-table-with-infinite-max-intrinsic-width.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210091
+  results:
+  - test: radiobutton-min-size.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210093
+  results:
+  - test: select-element-zero-height-001.html
+    status: FAIL
+  - test: select-element-zero-height-002.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210102
+  results:
+  - test: table-as-item-auto-min-width.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209871
+  results:
+  - test: align-content-wrap-001.html
+    status: FAIL
+  - test: align-content-wrap-002.html
+    status: FAIL
+  - test: align-content-wrap-003.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210077
+  results:
+  - test: flex-aspect-ratio-img-column-010.html
+    status: FAIL
+  - test: flex-basis-010.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=172026
+  results:
+  - test: flex-item-contains-strict.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210088
+  results:
+  - test: flex-minimum-height-flex-items-010.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210089
+  results:
+  - test: flex-minimum-height-flex-items-011.xht
+    status: FAIL
+  - test: flex-minimum-height-flex-items-013.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=185771
+  results:
+  - test: hittest-overlapping-margin.html
+    status: FAIL
+  - test: hittest-overlapping-order.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210103
+  results:
+  - test: item-with-table-with-infinite-max-intrinsic-width.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210091
+  results:
+  - test: radiobutton-min-size.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210093
+  results:
+  - test: select-element-zero-height-001.html
+    status: FAIL
+  - test: select-element-zero-height-002.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210102
+  results:
+  - test: table-as-item-auto-min-width.html
+    status: FAIL

--- a/css/css-flexbox/animation/META.yml
+++ b/css/css-flexbox/animation/META.yml
@@ -1,0 +1,45 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=180435
+  results:
+  - test: flex-basis-composition.html
+    status: FAIL
+  - test: flex-basis-interpolation.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209872
+  results:
+  - test: flex-grow-interpolation.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209874
+  results:
+  - test: flex-shrink-interpolation.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209876
+  results:
+  - test: order-interpolation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=180435
+  results:
+  - test: flex-basis-composition.html
+    status: FAIL
+  - test: flex-basis-interpolation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209872
+  results:
+  - test: flex-grow-interpolation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209874
+  results:
+  - test: flex-shrink-interpolation.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209876
+  results:
+  - test: order-interpolation.html
+    status: FAIL


### PR DESCRIPTION
This adds metadata for around 25 WebKit css-flexbox unique failures.
It also adds a bug related to unsupported css-contain spec.