### PR TITLE
Add metadata with more css-flexbox related failures for Safari and WebKitGTK

### DIFF
--- a/css/css-flexbox/META.yml
+++ b/css/css-flexbox/META.yml
@@ -133,3 +133,111 @@ links:
   results:
   - test: table-as-item-auto-min-width.html
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210144
+  results:
+  - test: anonymous-flex-item-004.html
+    status: FAIL
+  - test: anonymous-flex-item-005.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210465
+  results:
+  - test: flex-wrap-002.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209871
+  results:
+  - test: flex-wrap-005.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=145176
+  results:
+  - test: flexbox_align-items-stretch-3.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210474
+  results:
+  - test: flexbox_first-letter.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=136754
+  results:
+  - test: flexbox_stf-table-singleline-2.html
+    status: FAIL
+  - test: flexbox_stf-table-singleline.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210475
+  results:
+  - test: image-items-flake-001.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210477
+  results:
+  - test: percentage-heights-003.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210478
+  results:
+  - test: percentage-heights-006.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210243
+  results:
+  - test: percentage-size-quirks.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210144
+  results:
+  - test: anonymous-flex-item-004.html
+    status: FAIL
+  - test: anonymous-flex-item-005.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210465
+  results:
+  - test: flex-wrap-002.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209871
+  results:
+  - test: flex-wrap-005.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=145176
+  results:
+  - test: flexbox_align-items-stretch-3.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210474
+  results:
+  - test: flexbox_first-letter.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=136754
+  results:
+  - test: flexbox_stf-table-singleline-2.html
+    status: FAIL
+  - test: flexbox_stf-table-singleline.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210475
+  results:
+  - test: image-items-flake-001.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210477
+  results:
+  - test: percentage-heights-003.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210478
+  results:
+  - test: percentage-heights-006.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210243
+  results:
+  - test: percentage-size-quirks.html
+    status: FAIL

--- a/css/css-flexbox/getcomputedstyle/META.yml
+++ b/css/css-flexbox/getcomputedstyle/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209651
+  results:
+  - test: flexbox_computedstyle_min-auto-size.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209651
+  results:
+  - test: flexbox_computedstyle_min-auto-size.html
+    status: FAIL


### PR DESCRIPTION
With this new round of expected failures triagging, almost all css-flexbox related unique failures for Safari/WebKitGTK are triagged.