### PR TITLE
Add more metadata for Safari and WebKitGTK (sync from layout-tests data)

### DIFF
--- a/2dcontext/compositing/META.yml
+++ b/2dcontext/compositing/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=202459
+  results:
+  - test: 2d.composite.globalAlpha.canvascopy.html
+    status: FAIL

--- a/2dcontext/drawing-images-to-the-canvas/META.yml
+++ b/2dcontext/drawing-images-to-the-canvas/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: 2d.drawImage.broken.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=202457
+  results:
+  - test: drawimage_canvas.html
+    status: FAIL

--- a/2dcontext/drawing-images-to-the-canvas/META.yml
+++ b/2dcontext/drawing-images-to-the-canvas/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202455
+  results:
+  - test: 2d.drawImage.broken.html
+    status: FAIL

--- a/2dcontext/image-smoothing/META.yml
+++ b/2dcontext/image-smoothing/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202460
+  results:
+  - test: imagesmoothing.html
+    status: FAIL

--- a/2dcontext/image-smoothing/META.yml
+++ b/2dcontext/image-smoothing/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: imagesmoothing.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=202460
+  results:
+  - test: imagesmoothing.html
+    status: FAIL

--- a/2dcontext/imagebitmap/META.yml
+++ b/2dcontext/imagebitmap/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202458
+  results:
+  - test: canvas-createImageBitmap-resize.html
+    status: FAIL

--- a/2dcontext/path-objects/META.yml
+++ b/2dcontext/path-objects/META.yml
@@ -1,0 +1,11 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202516
+  results:
+  - test: 2d.path.rect.winding.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202523
+  results:
+  - test: 2d.path.stroke.scale2.html
+    status: FAIL

--- a/2dcontext/shadows/META.yml
+++ b/2dcontext/shadows/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206587
+  results:
+  - test: shadowBlur_gaussian_tolerance.1.html
+    status: FAIL

--- a/2dcontext/text-styles/META.yml
+++ b/2dcontext/text-styles/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: 2d.text.draw.baseline.ideographic.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=202517
+  results:
+  - test: 2d.text.draw.baseline.ideographic.html
+    status: FAIL

--- a/2dcontext/text-styles/META.yml
+++ b/2dcontext/text-styles/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202517
+  results:
+  - test: 2d.text.draw.baseline.ideographic.html
+    status: FAIL

--- a/IndexedDB/META.yml
+++ b/IndexedDB/META.yml
@@ -8,3 +8,12 @@ links:
     status: FAIL
   - test: nested-cloning-small.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=184066
+  results:
+  - test: nested-cloning-large-multiple.html
+    status: FAIL
+  - test: nested-cloning-large.html
+    status: FAIL
+  - test: nested-cloning-small.html
+    status: FAIL

--- a/IndexedDB/META.yml
+++ b/IndexedDB/META.yml
@@ -1,0 +1,10 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=184066
+  results:
+  - test: nested-cloning-large-multiple.html
+    status: FAIL
+  - test: nested-cloning-large.html
+    status: FAIL
+  - test: nested-cloning-small.html
+    status: FAIL

--- a/clipboard-apis/META.yml
+++ b/clipboard-apis/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206653
+  results:
+  - test: async-navigator-clipboard-basics.https.html
+    status: FAIL

--- a/content-security-policy/frame-src/META.yml
+++ b/content-security-policy/frame-src/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206586
+  results:
+  - test: frame-src-same-document-meta.html
+    status: TIMEOUT

--- a/cors/META.yml
+++ b/cors/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206874
+  results:
+  - test: origin.htm
+    status: FAIL

--- a/css/css-backgrounds/META.yml
+++ b/css/css-backgrounds/META.yml
@@ -1,0 +1,42 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: background-image-007.html
+    status: FAIL
+  - test: background-position-negative-percentage-comparison.html
+    status: FAIL
+  - test: background-size-cover-003.html
+    status: FAIL
+  - test: background-size-with-negative-value.html
+    status: FAIL
+  - test: border-image-repeat-round.html
+    status: FAIL
+  - test: border-image-round-and-stretch.html
+    status: FAIL
+  - test: border-image-slice-003.xht
+    status: FAIL
+  - test: border-image-slice-percentage.html
+    status: FAIL
+  - test: border-image-space-001.html
+    status: FAIL
+  - test: border-image-width-005.xht
+    status: FAIL
+  - test: border-image-width-006.xht
+    status: FAIL
+  - test: border-image-width-007.xht
+    status: FAIL
+  - test: border-image-width-008.html
+    status: FAIL
+  - test: border-radius-clipping.html
+    status: FAIL
+  - test: css-border-radius-001.html
+    status: FAIL
+  - test: css-border-radius-002.html
+    status: FAIL
+  - test: css3-border-image-repeat-repeat.html
+    status: FAIL
+  - test: css3-border-image-repeat-stretch.html
+    status: FAIL
+  - test: first-letter-space-not-selected.html
+    status: FAIL

--- a/css/css-backgrounds/META.yml
+++ b/css/css-backgrounds/META.yml
@@ -40,3 +40,55 @@ links:
     status: FAIL
   - test: first-letter-space-not-selected.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206756
+  results:
+  - test: background-size-025.html
+    status: FAIL
+  - test: background-size-027.html
+    status: FAIL
+  - test: background-size-029.html
+    status: FAIL
+  - test: border-image-repeat-005.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: background-image-007.html
+    status: FAIL
+  - test: background-position-negative-percentage-comparison.html
+    status: FAIL
+  - test: background-size-cover-003.html
+    status: FAIL
+  - test: background-size-with-negative-value.html
+    status: FAIL
+  - test: border-image-repeat-round.html
+    status: FAIL
+  - test: border-image-round-and-stretch.html
+    status: FAIL
+  - test: border-image-slice-003.xht
+    status: FAIL
+  - test: border-image-slice-percentage.html
+    status: FAIL
+  - test: border-image-space-001.html
+    status: FAIL
+  - test: border-image-width-005.xht
+    status: FAIL
+  - test: border-image-width-006.xht
+    status: FAIL
+  - test: border-image-width-007.xht
+    status: FAIL
+  - test: border-image-width-008.html
+    status: FAIL
+  - test: border-radius-clipping.html
+    status: FAIL
+  - test: css-border-radius-001.html
+    status: FAIL
+  - test: css-border-radius-002.html
+    status: FAIL
+  - test: css3-border-image-repeat-repeat.html
+    status: FAIL
+  - test: css3-border-image-repeat-stretch.html
+    status: FAIL
+  - test: first-letter-space-not-selected.html
+    status: FAIL

--- a/css/css-backgrounds/background-attachment-local/META.yml
+++ b/css/css-backgrounds/background-attachment-local/META.yml
@@ -5,3 +5,18 @@ links:
   - test: attachment-local-clipping-image-2.html
   - test: attachment-local-clipping-image-3.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1560210
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: attachment-local-clipping-color-4.html
+    status: FAIL
+  - test: attachment-local-clipping-color-6.html
+    status: FAIL
+  - test: attachment-local-clipping-image-4.html
+    status: FAIL
+  - test: attachment-local-clipping-image-6.html
+    status: FAIL
+  - test: attachment-local-positioning-3.html
+    status: FAIL
+  - test: attachment-local-positioning-4.html
+    status: FAIL

--- a/css/css-backgrounds/background-attachment-local/META.yml
+++ b/css/css-backgrounds/background-attachment-local/META.yml
@@ -20,3 +20,18 @@ links:
     status: FAIL
   - test: attachment-local-positioning-4.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: attachment-local-clipping-color-4.html
+    status: FAIL
+  - test: attachment-local-clipping-color-6.html
+    status: FAIL
+  - test: attachment-local-clipping-image-4.html
+    status: FAIL
+  - test: attachment-local-clipping-image-6.html
+    status: FAIL
+  - test: attachment-local-positioning-3.html
+    status: FAIL
+  - test: attachment-local-positioning-4.html
+    status: FAIL

--- a/css/css-backgrounds/background-repeat/META.yml
+++ b/css/css-backgrounds/background-repeat/META.yml
@@ -1,0 +1,10 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: background-repeat-round-roundup.xht
+    status: FAIL
+  - test: background-repeat-round.xht
+    status: FAIL
+  - test: background-repeat-space.xht
+    status: FAIL

--- a/css/css-backgrounds/background-size/META.yml
+++ b/css/css-backgrounds/background-size/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: background-size-contain.xht
+    status: FAIL

--- a/css/css-backgrounds/background-size/vector/META.yml
+++ b/css/css-backgrounds/background-size/vector/META.yml
@@ -244,3 +244,248 @@ links:
     status: FAIL
   - test: wide--cover--width.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: background-size-vector-003.html
+    status: FAIL
+  - test: background-size-vector-004.html
+    status: FAIL
+  - test: background-size-vector-005.html
+    status: FAIL
+  - test: background-size-vector-006.html
+    status: FAIL
+  - test: background-size-vector-007.html
+    status: FAIL
+  - test: background-size-vector-008.html
+    status: FAIL
+  - test: background-size-vector-009.html
+    status: FAIL
+  - test: background-size-vector-010.html
+    status: FAIL
+  - test: background-size-vector-011.html
+    status: FAIL
+  - test: background-size-vector-012.html
+    status: FAIL
+  - test: background-size-vector-013.html
+    status: FAIL
+  - test: background-size-vector-014.html
+    status: FAIL
+  - test: background-size-vector-015.html
+    status: FAIL
+  - test: background-size-vector-016.html
+    status: FAIL
+  - test: background-size-vector-017.html
+    status: FAIL
+  - test: background-size-vector-018.html
+    status: FAIL
+  - test: background-size-vector-021.html
+    status: FAIL
+  - test: background-size-vector-023.html
+    status: FAIL
+  - test: background-size-vector-025.html
+    status: FAIL
+  - test: background-size-vector-027.html
+    status: FAIL
+  - test: background-size-vector-029.html
+    status: FAIL
+  - test: diagonal-percentage-vector-background.html
+    status: FAIL
+  - test: tall--auto--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-omitted-height.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-percent-height.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-omitted-height.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-percent-height.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: tall--contain--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--omitted-width-nonpercent-height.html
+    status: FAIL
+  - test: tall--contain--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--percent-width-nonpercent-height.html
+    status: FAIL
+  - test: tall--contain--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--height.html
+    status: FAIL
+  - test: tall--cover--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: tall--cover--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: tall--cover--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--width.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-omitted-height.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-percent-height.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-omitted-height.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-percent-height.html
+    status: FAIL
+  - test: wide--auto--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-omitted-height.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-percent-height.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-omitted-height.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-percent-height.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--contain--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--omitted-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--contain--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--percent-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--contain--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--height.html
+    status: FAIL
+  - test: wide--cover--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--cover--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--cover--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--width.html
+    status: FAIL

--- a/css/css-backgrounds/background-size/vector/META.yml
+++ b/css/css-backgrounds/background-size/vector/META.yml
@@ -1,0 +1,246 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=206753
+  results:
+  - test: background-size-vector-003.html
+    status: FAIL
+  - test: background-size-vector-004.html
+    status: FAIL
+  - test: background-size-vector-005.html
+    status: FAIL
+  - test: background-size-vector-006.html
+    status: FAIL
+  - test: background-size-vector-007.html
+    status: FAIL
+  - test: background-size-vector-008.html
+    status: FAIL
+  - test: background-size-vector-009.html
+    status: FAIL
+  - test: background-size-vector-010.html
+    status: FAIL
+  - test: background-size-vector-011.html
+    status: FAIL
+  - test: background-size-vector-012.html
+    status: FAIL
+  - test: background-size-vector-013.html
+    status: FAIL
+  - test: background-size-vector-014.html
+    status: FAIL
+  - test: background-size-vector-015.html
+    status: FAIL
+  - test: background-size-vector-016.html
+    status: FAIL
+  - test: background-size-vector-017.html
+    status: FAIL
+  - test: background-size-vector-018.html
+    status: FAIL
+  - test: background-size-vector-021.html
+    status: FAIL
+  - test: background-size-vector-023.html
+    status: FAIL
+  - test: background-size-vector-025.html
+    status: FAIL
+  - test: background-size-vector-027.html
+    status: FAIL
+  - test: background-size-vector-029.html
+    status: FAIL
+  - test: diagonal-percentage-vector-background.html
+    status: FAIL
+  - test: tall--auto--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-omitted-height.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--omitted-width-percent-height.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-omitted-height.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--auto-32px--percent-width-percent-height.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: tall--contain--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--omitted-width-nonpercent-height.html
+    status: FAIL
+  - test: tall--contain--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--percent-width-nonpercent-height.html
+    status: FAIL
+  - test: tall--contain--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--contain--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--height.html
+    status: FAIL
+  - test: tall--cover--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: tall--cover--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: tall--cover--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: tall--cover--width.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-omitted-height.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--omitted-width-percent-height.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-omitted-height.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--12px-auto--percent-width-percent-height.html
+    status: FAIL
+  - test: wide--auto--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-omitted-height.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--omitted-width-percent-height.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-omitted-height.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--auto-32px--percent-width-percent-height.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--contain--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--omitted-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--contain--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--percent-width-nonpercent-height.html
+    status: FAIL
+  - test: wide--contain--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--contain--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--height.html
+    status: FAIL
+  - test: wide--cover--nonpercent-width-omitted-height.html
+    status: FAIL
+  - test: wide--cover--nonpercent-width-percent-height.html
+    status: FAIL
+  - test: wide--cover--omitted-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--omitted-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--omitted-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--percent-width-nonpercent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--percent-width-omitted-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--percent-width-percent-height-viewbox.html
+    status: FAIL
+  - test: wide--cover--width.html
+    status: FAIL

--- a/css/css-cascade/META.yml
+++ b/css/css-cascade/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209330
+  results:
+  - test: all-prop-initial-xml.html
+    status: FAIL

--- a/css/css-flexbox/META.yml
+++ b/css/css-flexbox/META.yml
@@ -241,3 +241,13 @@ links:
   results:
   - test: percentage-size-quirks.html
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210791
+  results:
+  - test: quirks-auto-block-size-with-percentage-item.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210791
+  results:
+  - test: quirks-auto-block-size-with-percentage-item.html
+    status: FAIL

--- a/css/css-fonts/META.yml
+++ b/css/css-fonts/META.yml
@@ -38,3 +38,10 @@ links:
     status: FAIL
   - test: font-size-adjust-005.xht
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=206883
+  results:
+  - test: font-default-01.html
+    status: FAIL
+  - test: font-default-02.html
+    status: FAIL

--- a/css/css-fonts/META.yml
+++ b/css/css-fonts/META.yml
@@ -45,3 +45,8 @@ links:
     status: FAIL
   - test: font-default-02.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206885
+  results:
+  - test: quoted-generic-ignored.html
+    status: FAIL

--- a/css/css-fonts/math-script-level-and-math-style/META.yml
+++ b/css/css-fonts/math-script-level-and-math-style/META.yml
@@ -1,0 +1,10 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=206881
+  results:
+  - test: math-script-level-auto-and-math-style-002.tentative.html
+    status: FAIL
+  - test: math-script-level-auto-and-math-style-003.tentative.html
+    status: FAIL
+  - test: math-script-level-auto-and-math-style-004.tentative.html
+    status: FAIL

--- a/css/css-fonts/math-script-level-and-math-style/META.yml
+++ b/css/css-fonts/math-script-level-and-math-style/META.yml
@@ -8,3 +8,12 @@ links:
     status: FAIL
   - test: math-script-level-auto-and-math-style-004.tentative.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206881
+  results:
+  - test: math-script-level-auto-and-math-style-002.tentative.html
+    status: FAIL
+  - test: math-script-level-auto-and-math-style-003.tentative.html
+    status: FAIL
+  - test: math-script-level-auto-and-math-style-004.tentative.html
+    status: FAIL

--- a/css/css-fonts/variations/META.yml
+++ b/css/css-fonts/variations/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: at-font-face-font-matching.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206882
+  results:
+  - test: at-font-face-font-matching.html
+    status: FAIL

--- a/css/css-fonts/variations/META.yml
+++ b/css/css-fonts/variations/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=206882
+  results:
+  - test: at-font-face-font-matching.html
+    status: FAIL

--- a/css/css-logical/META.yml
+++ b/css/css-logical/META.yml
@@ -33,3 +33,8 @@ links:
   - subtest: Physical shorthands using variables win over logical shorthands
     test: animation-001.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1520069
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=190032
+  results:
+  - test: animation-003.tentative.html
+    status: FAIL

--- a/css/css-logical/META.yml
+++ b/css/css-logical/META.yml
@@ -38,3 +38,8 @@ links:
   results:
   - test: animation-003.tentative.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=190032
+  results:
+  - test: animation-003.tentative.html
+    status: FAIL

--- a/css/css-overflow/META.yml
+++ b/css/css-overflow/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206409
+  results:
+  - test: overflow-padding.html
+    status: FAIL

--- a/css/css-sizing/META.yml
+++ b/css/css-sizing/META.yml
@@ -110,3 +110,13 @@ links:
   results:
   - test: whitespace-and-break.html
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=210784
+  results:
+  - test: percentage-height-in-flexbox.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210784
+  results:
+  - test: percentage-height-in-flexbox.html
+    status: FAIL

--- a/css/css-transitions/META.yml
+++ b/css/css-transitions/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: before-load-001.html
     status: TIMEOUT
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203416
+  results:
+  - test: properties-value-auto-001.html
+    status: FAIL

--- a/css/css-transitions/META.yml
+++ b/css/css-transitions/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=203416
+  results:
+  - test: before-load-001.html
+    status: TIMEOUT

--- a/css/css-ui/META.yml
+++ b/css/css-ui/META.yml
@@ -63,3 +63,8 @@ links:
     status: FAIL
   - test: outline-019.html
     status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=175291
+  results:
+  - test: outline-018.html
+    status: FAIL

--- a/css/css-ui/META.yml
+++ b/css/css-ui/META.yml
@@ -68,3 +68,8 @@ links:
   results:
   - test: outline-018.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=175291
+  results:
+  - test: outline-018.html
+    status: FAIL

--- a/css/css-values/META.yml
+++ b/css/css-values/META.yml
@@ -184,3 +184,17 @@ links:
     status: FAIL
   - test: lh-unit-002.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206001
+  results:
+  - test: ch-unit-016.html
+    status: FAIL
+  - test: ch-unit-017.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=203333
+  results:
+  - test: ch-unit-002.html
+    status: FAIL
+  - test: ch-unit-011.html
+    status: FAIL

--- a/css/css-writing-modes/META.yml
+++ b/css/css-writing-modes/META.yml
@@ -1,0 +1,556 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=209080
+  results:
+  - test: abs-pos-non-replaced-icb-vlr-003.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-005.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-011.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-013.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-033.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-002.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-004.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-006.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-008.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-010.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-012.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-014.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-016.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-018.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-020.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-030.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-005.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-017.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-029.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-041.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-053.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-065.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-077.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-089.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-095.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-105.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-109.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-121.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-125.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-137.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-141.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-153.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-157.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-169.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-173.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-185.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-189.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-201.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-205.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-217.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-221.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-225.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-229.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-004.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-010.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-016.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-028.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-034.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-040.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-052.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-064.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-076.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-088.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-104.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-108.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-112.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-116.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-124.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-128.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-136.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-140.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-144.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-148.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-156.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-160.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-172.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-176.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-188.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-192.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-204.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-208.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-220.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-224.xht
+    status: FAIL
+  - test: available-size-001.html
+    status: FAIL
+  - test: available-size-002.html
+    status: FAIL
+  - test: available-size-003.html
+    status: FAIL
+  - test: available-size-005.html
+    status: FAIL
+  - test: available-size-006.html
+    status: FAIL
+  - test: available-size-007.html
+    status: FAIL
+  - test: available-size-008.html
+    status: FAIL
+  - test: available-size-009.html
+    status: FAIL
+  - test: available-size-010.html
+    status: FAIL
+  - test: available-size-012.html
+    status: FAIL
+  - test: available-size-013.html
+    status: FAIL
+  - test: available-size-014.html
+    status: FAIL
+  - test: available-size-015.html
+    status: FAIL
+  - test: available-size-016.html
+    status: FAIL
+  - test: available-size-017.html
+    status: FAIL
+  - test: available-size-019.html
+    status: FAIL
+  - test: background-position-vrl-018.xht
+    status: FAIL
+  - test: background-position-vrl-020.xht
+    status: FAIL
+  - test: background-position-vrl-022.xht
+    status: FAIL
+  - test: background-size-document-root-vrl-002.html
+    status: FAIL
+  - test: background-size-document-root-vrl-004.html
+    status: FAIL
+  - test: background-size-document-root-vrl-006.html
+    status: FAIL
+  - test: background-size-document-root-vrl-008.html
+    status: FAIL
+  - test: bidi-plaintext-011.html
+    status: FAIL
+  - test: block-flow-direction-slr-043.xht
+    status: FAIL
+  - test: block-flow-direction-slr-047.xht
+    status: FAIL
+  - test: block-flow-direction-slr-048.xht
+    status: FAIL
+  - test: block-flow-direction-slr-050.xht
+    status: FAIL
+  - test: block-flow-direction-slr-054.xht
+    status: FAIL
+  - test: block-flow-direction-slr-055.xht
+    status: FAIL
+  - test: block-flow-direction-slr-056.xht
+    status: FAIL
+  - test: block-flow-direction-slr-058.xht
+    status: FAIL
+  - test: block-flow-direction-slr-060.xht
+    status: FAIL
+  - test: block-flow-direction-slr-062.xht
+    status: FAIL
+  - test: block-flow-direction-slr-063.xht
+    status: FAIL
+  - test: block-flow-direction-slr-066.xht
+    status: FAIL
+  - test: block-flow-direction-srl-042.xht
+    status: FAIL
+  - test: block-flow-direction-srl-045.xht
+    status: FAIL
+  - test: block-flow-direction-srl-046.xht
+    status: FAIL
+  - test: block-flow-direction-srl-049.xht
+    status: FAIL
+  - test: block-flow-direction-srl-051.xht
+    status: FAIL
+  - test: block-flow-direction-srl-052.xht
+    status: FAIL
+  - test: block-flow-direction-srl-053.xht
+    status: FAIL
+  - test: block-flow-direction-srl-057.xht
+    status: FAIL
+  - test: block-flow-direction-srl-059.xht
+    status: FAIL
+  - test: block-flow-direction-srl-061.xht
+    status: FAIL
+  - test: block-flow-direction-srl-064.xht
+    status: FAIL
+  - test: block-flow-direction-srl-065.xht
+    status: FAIL
+  - test: block-flow-direction-vlr-018.xht
+    status: FAIL
+  - test: block-flow-direction-vrl-009.xht
+    status: FAIL
+  - test: block-flow-direction-vrl-017.xht
+    status: FAIL
+  - test: border-conflict-element-vlr-003.xht
+    status: FAIL
+  - test: border-conflict-element-vlr-005.xht
+    status: FAIL
+  - test: border-conflict-element-vrl-002.xht
+    status: FAIL
+  - test: border-conflict-element-vrl-004.xht
+    status: FAIL
+  - test: ch-units-vrl-001.html
+    status: FAIL
+  - test: ch-units-vrl-002.html
+    status: FAIL
+  - test: ch-units-vrl-005.html
+    status: FAIL
+  - test: ch-units-vrl-006.html
+    status: FAIL
+  - test: ch-units-vrl-007.html
+    status: FAIL
+  - test: ch-units-vrl-008.html
+    status: FAIL
+  - test: clearance-calculations-vrl-006.xht
+    status: FAIL
+  - test: clip-rect-vlr-003.xht
+    status: FAIL
+  - test: clip-rect-vlr-005.xht
+    status: FAIL
+  - test: clip-rect-vlr-007.xht
+    status: FAIL
+  - test: clip-rect-vlr-009.xht
+    status: FAIL
+  - test: clip-rect-vrl-002.xht
+    status: FAIL
+  - test: clip-rect-vrl-004.xht
+    status: FAIL
+  - test: clip-rect-vrl-006.xht
+    status: FAIL
+  - test: clip-rect-vrl-008.xht
+    status: FAIL
+  - test: float-in-htb-in-vrl.html
+    status: FAIL
+  - test: full-width-001.html
+    status: FAIL
+  - test: inline-block-alignment-003.xht
+    status: FAIL
+  - test: inline-block-alignment-005.xht
+    status: FAIL
+  - test: inline-block-alignment-007.xht
+    status: FAIL
+  - test: inline-block-alignment-slr-009.xht
+    status: FAIL
+  - test: inline-block-alignment-srl-008.xht
+    status: FAIL
+  - test: inline-table-alignment-003.xht
+    status: FAIL
+  - test: inline-table-alignment-005.xht
+    status: FAIL
+  - test: line-box-direction-slr-043.xht
+    status: FAIL
+  - test: line-box-direction-slr-047.xht
+    status: FAIL
+  - test: line-box-direction-slr-048.xht
+    status: FAIL
+  - test: line-box-direction-slr-050.xht
+    status: FAIL
+  - test: line-box-direction-slr-053.xht
+    status: FAIL
+  - test: line-box-direction-slr-054.xht
+    status: FAIL
+  - test: line-box-direction-slr-056.xht
+    status: FAIL
+  - test: line-box-direction-slr-058.xht
+    status: FAIL
+  - test: line-box-direction-slr-060.xht
+    status: FAIL
+  - test: line-box-direction-srl-042.xht
+    status: FAIL
+  - test: line-box-direction-srl-045.xht
+    status: FAIL
+  - test: line-box-direction-srl-046.xht
+    status: FAIL
+  - test: line-box-direction-srl-049.xht
+    status: FAIL
+  - test: line-box-direction-srl-051.xht
+    status: FAIL
+  - test: line-box-direction-srl-052.xht
+    status: FAIL
+  - test: line-box-direction-srl-055.xht
+    status: FAIL
+  - test: line-box-direction-srl-057.xht
+    status: FAIL
+  - test: line-box-direction-srl-059.xht
+    status: FAIL
+  - test: line-box-direction-vlr-016.xht
+    status: FAIL
+  - test: line-box-direction-vrl-009.xht
+    status: FAIL
+  - test: line-box-direction-vrl-015.xht
+    status: FAIL
+  - test: line-box-height-vlr-007.xht
+    status: FAIL
+  - test: line-box-height-vlr-009.xht
+    status: FAIL
+  - test: line-box-height-vlr-011.xht
+    status: FAIL
+  - test: line-box-height-vlr-013.xht
+    status: FAIL
+  - test: line-box-height-vlr-021.xht
+    status: FAIL
+  - test: line-box-height-vlr-023.xht
+    status: FAIL
+  - test: mongolian-orientation-001.html
+    status: FAIL
+  - test: mongolian-orientation-002.html
+    status: FAIL
+  - test: nested-orthogonal-001.html
+    status: FAIL
+  - test: normal-flow-overconstrained-vrl-002.xht
+    status: FAIL
+  - test: normal-flow-overconstrained-vrl-004.xht
+    status: FAIL
+  - test: outline-inline-vlr-006.html
+    status: FAIL
+  - test: outline-inline-vrl-006.html
+    status: FAIL
+  - test: overconstrained-rel-pos-ltr-left-right-vrl-004.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-ltr-top-bottom-vrl-002.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-rtl-left-right-vlr-009.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-rtl-left-right-vrl-008.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-rtl-top-bottom-vlr-007.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-rtl-top-bottom-vrl-006.xht
+    status: FAIL
+  - test: row-progression-slr-023.xht
+    status: FAIL
+  - test: row-progression-slr-029.xht
+    status: FAIL
+  - test: row-progression-srl-022.xht
+    status: FAIL
+  - test: row-progression-srl-028.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vlr-001.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vlr-004.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vrl-001.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vrl-004.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vlr-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vlr-002.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vrl-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vrl-002.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vlr-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vlr-in-htb-002.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vrl-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vrl-in-htb-002.xht
+    status: FAIL
+  - test: sizing-orthog-vlr-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-vlr-in-htb-004.xht
+    status: FAIL
+  - test: sizing-orthog-vrl-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-vrl-in-htb-004.xht
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-001.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-002.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-003.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-004.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-005.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-006.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-007.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-008.html
+    status: FAIL
+  - test: sizing-percentages-replaced-orthogonal-001.html
+    status: FAIL
+  - test: table-cell-001.html
+    status: FAIL
+  - test: table-cell-002.html
+    status: FAIL
+  - test: table-column-order-002.xht
+    status: FAIL
+  - test: table-column-order-003.xht
+    status: FAIL
+  - test: table-column-order-004.xht
+    status: FAIL
+  - test: table-column-order-005.xht
+    status: FAIL
+  - test: table-column-order-slr-007.xht
+    status: FAIL
+  - test: table-column-order-srl-006.xht
+    status: FAIL
+  - test: table-progression-slr-001.html
+    status: FAIL
+  - test: table-progression-slr-002.html
+    status: FAIL
+  - test: table-progression-srl-001.html
+    status: FAIL
+  - test: table-progression-srl-002.html
+    status: FAIL
+  - test: table-progression-vlr-001.html
+    status: FAIL
+  - test: table-progression-vlr-003.html
+    status: FAIL
+  - test: table-progression-vlr-004.html
+    status: FAIL
+  - test: table-progression-vrl-001.html
+    status: FAIL
+  - test: table-progression-vrl-003.html
+    status: FAIL
+  - test: table-progression-vrl-004.html
+    status: FAIL
+  - test: text-baseline-slr-009.xht
+    status: FAIL
+  - test: text-baseline-srl-008.xht
+    status: FAIL
+  - test: text-combine-upright-layout-rules-001.html
+    status: FAIL
+  - test: text-combine-upright-line-breaking-rules-001.html
+    status: FAIL
+  - test: text-combine-upright-value-all-001.html
+    status: FAIL
+  - test: text-combine-upright-value-all-002.html
+    status: FAIL
+  - test: text-combine-upright-value-all-003.html
+    status: FAIL
+  - test: text-combine-upright-value-digits2-001.html
+    status: FAIL
+  - test: text-combine-upright-value-digits2-002.html
+    status: FAIL
+  - test: text-combine-upright-value-digits3-001.html
+    status: FAIL
+  - test: text-combine-upright-value-digits3-002.html
+    status: FAIL
+  - test: text-combine-upright-value-digits4-001.html
+    status: FAIL
+  - test: text-combine-upright-value-digits4-002.html
+    status: FAIL
+  - test: text-orientation-mixed-srl-016.xht
+    status: FAIL
+  - test: text-orientation-mixed-vlr-100.html
+    status: FAIL
+  - test: text-orientation-mixed-vrl-100.html
+    status: FAIL
+  - test: text-orientation-sideways-vlr-100.html
+    status: FAIL
+  - test: text-orientation-sideways-vrl-100.html
+    status: FAIL
+  - test: text-orientation-upright-srl-018.xht
+    status: FAIL
+  - test: text-orientation-upright-vlr-100.html
+    status: FAIL
+  - test: text-orientation-upright-vrl-100.html
+    status: FAIL
+  - test: three-levels-of-orthogonal-flows.html
+    status: FAIL
+  - test: two-levels-of-orthogonal-flows-fixed.html
+    status: FAIL
+  - test: two-levels-of-orthogonal-flows-percentage.html
+    status: FAIL
+  - test: two-levels-of-orthogonal-flows.html
+    status: FAIL
+  - test: vertical-alignment-003.xht
+    status: FAIL
+  - test: vertical-alignment-009.xht
+    status: FAIL
+  - test: vertical-alignment-slr-029.xht
+    status: FAIL
+  - test: vertical-alignment-slr-031.xht
+    status: FAIL
+  - test: vertical-alignment-slr-033.xht
+    status: FAIL
+  - test: vertical-alignment-slr-035.xht
+    status: FAIL
+  - test: vertical-alignment-slr-041.xht
+    status: FAIL
+  - test: vertical-alignment-srl-028.xht
+    status: FAIL
+  - test: vertical-alignment-srl-030.xht
+    status: FAIL
+  - test: vertical-alignment-srl-032.xht
+    status: FAIL
+  - test: vertical-alignment-srl-034.xht
+    status: FAIL
+  - test: vertical-alignment-srl-040.xht
+    status: FAIL

--- a/css/css-writing-modes/META.yml
+++ b/css/css-writing-modes/META.yml
@@ -554,3 +554,563 @@ links:
     status: FAIL
   - test: vertical-alignment-srl-040.xht
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209275
+  results:
+  - test: central-baseline-alignment-002.xht
+    status: FAIL
+  - test: central-baseline-alignment-003.xht
+    status: FAIL
+  - test: inline-block-alignment-004.xht
+    status: FAIL
+  - test: inline-block-alignment-orthogonal-vlr-005.xht
+    status: FAIL
+  - test: inline-block-alignment-orthogonal-vrl-004.xht
+    status: FAIL
+  - test: inline-table-alignment-004.xht
+    status: FAIL
+  - test: line-box-height-vlr-003.xht
+    status: FAIL
+  - test: line-box-height-vlr-005.xht
+    status: FAIL
+  - test: line-box-height-vrl-010.xht
+    status: FAIL
+  - test: line-box-height-vrl-012.xht
+    status: FAIL
+  - test: sizing-orthog-vlr-in-htb-020.xht
+    status: FAIL
+  - test: sizing-orthog-vrl-in-htb-020.xht
+    status: FAIL
+  - test: text-baseline-vlr-005.xht
+    status: FAIL
+  - test: text-baseline-vrl-004.xht
+    status: FAIL
+  - test: vertical-alignment-vlr-023.xht
+    status: FAIL
+  - test: vertical-alignment-vrl-022.xht
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209080
+  results:
+  - test: abs-pos-non-replaced-icb-vlr-003.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-005.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-011.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-013.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vlr-033.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-002.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-004.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-006.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-008.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-010.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-012.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-014.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-016.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-018.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-020.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-icb-vrl-030.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-005.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-017.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-029.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-041.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-053.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-065.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-077.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-089.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-095.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-105.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-109.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-121.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-125.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-137.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-141.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-153.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-157.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-169.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-173.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-185.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-189.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-201.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-205.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-217.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-221.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-225.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vlr-229.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-004.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-010.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-016.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-028.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-034.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-040.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-052.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-064.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-076.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-088.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-104.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-108.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-112.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-116.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-124.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-128.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-136.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-140.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-144.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-148.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-156.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-160.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-172.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-176.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-188.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-192.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-204.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-208.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-220.xht
+    status: FAIL
+  - test: abs-pos-non-replaced-vrl-224.xht
+    status: FAIL
+  - test: available-size-001.html
+    status: FAIL
+  - test: available-size-002.html
+    status: FAIL
+  - test: available-size-003.html
+    status: FAIL
+  - test: available-size-005.html
+    status: FAIL
+  - test: available-size-007.html
+    status: FAIL
+  - test: available-size-010.html
+    status: FAIL
+  - test: available-size-012.html
+    status: FAIL
+  - test: available-size-014.html
+    status: FAIL
+  - test: available-size-017.html
+    status: FAIL
+  - test: background-size-document-root-vrl-002.html
+    status: FAIL
+  - test: background-size-document-root-vrl-004.html
+    status: FAIL
+  - test: background-size-document-root-vrl-006.html
+    status: FAIL
+  - test: background-size-document-root-vrl-008.html
+    status: FAIL
+  - test: block-flow-direction-slr-043.xht
+    status: FAIL
+  - test: block-flow-direction-slr-047.xht
+    status: FAIL
+  - test: block-flow-direction-slr-048.xht
+    status: FAIL
+  - test: block-flow-direction-slr-050.xht
+    status: FAIL
+  - test: block-flow-direction-slr-054.xht
+    status: FAIL
+  - test: block-flow-direction-slr-055.xht
+    status: FAIL
+  - test: block-flow-direction-slr-056.xht
+    status: FAIL
+  - test: block-flow-direction-slr-058.xht
+    status: FAIL
+  - test: block-flow-direction-slr-060.xht
+    status: FAIL
+  - test: block-flow-direction-slr-062.xht
+    status: FAIL
+  - test: block-flow-direction-slr-063.xht
+    status: FAIL
+  - test: block-flow-direction-slr-066.xht
+    status: FAIL
+  - test: block-flow-direction-srl-042.xht
+    status: FAIL
+  - test: block-flow-direction-srl-045.xht
+    status: FAIL
+  - test: block-flow-direction-srl-046.xht
+    status: FAIL
+  - test: block-flow-direction-srl-049.xht
+    status: FAIL
+  - test: block-flow-direction-srl-051.xht
+    status: FAIL
+  - test: block-flow-direction-srl-052.xht
+    status: FAIL
+  - test: block-flow-direction-srl-053.xht
+    status: FAIL
+  - test: block-flow-direction-srl-057.xht
+    status: FAIL
+  - test: block-flow-direction-srl-059.xht
+    status: FAIL
+  - test: block-flow-direction-srl-061.xht
+    status: FAIL
+  - test: block-flow-direction-srl-064.xht
+    status: FAIL
+  - test: block-flow-direction-srl-065.xht
+    status: FAIL
+  - test: block-flow-direction-vlr-018.xht
+    status: FAIL
+  - test: block-flow-direction-vrl-009.xht
+    status: FAIL
+  - test: block-flow-direction-vrl-017.xht
+    status: FAIL
+  - test: border-conflict-element-vlr-003.xht
+    status: FAIL
+  - test: border-conflict-element-vlr-005.xht
+    status: FAIL
+  - test: border-conflict-element-vrl-002.xht
+    status: FAIL
+  - test: border-conflict-element-vrl-004.xht
+    status: FAIL
+  - test: ch-units-vrl-001.html
+    status: FAIL
+  - test: ch-units-vrl-002.html
+    status: FAIL
+  - test: ch-units-vrl-005.html
+    status: FAIL
+  - test: ch-units-vrl-006.html
+    status: FAIL
+  - test: clearance-calculations-vrl-006.xht
+    status: FAIL
+  - test: clip-rect-vlr-003.xht
+    status: FAIL
+  - test: clip-rect-vlr-005.xht
+    status: FAIL
+  - test: clip-rect-vlr-007.xht
+    status: FAIL
+  - test: clip-rect-vlr-009.xht
+    status: FAIL
+  - test: clip-rect-vrl-002.xht
+    status: FAIL
+  - test: clip-rect-vrl-004.xht
+    status: FAIL
+  - test: clip-rect-vrl-006.xht
+    status: FAIL
+  - test: clip-rect-vrl-008.xht
+    status: FAIL
+  - test: float-in-htb-in-vrl.html
+    status: FAIL
+  - test: full-width-001.html
+    status: FAIL
+  - test: inline-block-alignment-003.xht
+    status: FAIL
+  - test: inline-block-alignment-005.xht
+    status: FAIL
+  - test: inline-block-alignment-007.xht
+    status: FAIL
+  - test: inline-block-alignment-slr-009.xht
+    status: FAIL
+  - test: inline-block-alignment-srl-008.xht
+    status: FAIL
+  - test: inline-table-alignment-003.xht
+    status: FAIL
+  - test: inline-table-alignment-005.xht
+    status: FAIL
+  - test: line-box-direction-slr-043.xht
+    status: FAIL
+  - test: line-box-direction-slr-047.xht
+    status: FAIL
+  - test: line-box-direction-slr-048.xht
+    status: FAIL
+  - test: line-box-direction-slr-050.xht
+    status: FAIL
+  - test: line-box-direction-slr-053.xht
+    status: FAIL
+  - test: line-box-direction-slr-054.xht
+    status: FAIL
+  - test: line-box-direction-slr-056.xht
+    status: FAIL
+  - test: line-box-direction-slr-058.xht
+    status: FAIL
+  - test: line-box-direction-slr-060.xht
+    status: FAIL
+  - test: line-box-direction-srl-042.xht
+    status: FAIL
+  - test: line-box-direction-srl-045.xht
+    status: FAIL
+  - test: line-box-direction-srl-046.xht
+    status: FAIL
+  - test: line-box-direction-srl-049.xht
+    status: FAIL
+  - test: line-box-direction-srl-051.xht
+    status: FAIL
+  - test: line-box-direction-srl-052.xht
+    status: FAIL
+  - test: line-box-direction-srl-055.xht
+    status: FAIL
+  - test: line-box-direction-srl-057.xht
+    status: FAIL
+  - test: line-box-direction-srl-059.xht
+    status: FAIL
+  - test: line-box-direction-vlr-016.xht
+    status: FAIL
+  - test: line-box-direction-vrl-009.xht
+    status: FAIL
+  - test: line-box-direction-vrl-015.xht
+    status: FAIL
+  - test: line-box-height-vlr-007.xht
+    status: FAIL
+  - test: line-box-height-vlr-009.xht
+    status: FAIL
+  - test: line-box-height-vlr-011.xht
+    status: FAIL
+  - test: line-box-height-vlr-013.xht
+    status: FAIL
+  - test: line-box-height-vlr-021.xht
+    status: FAIL
+  - test: line-box-height-vlr-023.xht
+    status: FAIL
+  - test: mongolian-orientation-001.html
+    status: FAIL
+  - test: mongolian-orientation-002.html
+    status: FAIL
+  - test: nested-orthogonal-001.html
+    status: FAIL
+  - test: outline-inline-vlr-006.html
+    status: FAIL
+  - test: outline-inline-vrl-006.html
+    status: FAIL
+  - test: overconstrained-rel-pos-ltr-left-right-vrl-004.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-rtl-left-right-vlr-009.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-rtl-top-bottom-vlr-007.xht
+    status: FAIL
+  - test: overconstrained-rel-pos-rtl-top-bottom-vrl-006.xht
+    status: FAIL
+  - test: row-progression-slr-023.xht
+    status: FAIL
+  - test: row-progression-slr-029.xht
+    status: FAIL
+  - test: row-progression-srl-022.xht
+    status: FAIL
+  - test: row-progression-srl-028.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vlr-001.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vlr-004.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vrl-001.xht
+    status: FAIL
+  - test: sizing-orthog-htb-in-vrl-004.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vlr-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vlr-002.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vrl-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-htb-in-vrl-002.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vlr-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vlr-in-htb-002.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vrl-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-prct-vrl-in-htb-002.xht
+    status: FAIL
+  - test: sizing-orthog-vlr-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-vlr-in-htb-004.xht
+    status: FAIL
+  - test: sizing-orthog-vlr-in-htb-008.xht
+    status: FAIL
+  - test: sizing-orthog-vrl-in-htb-001.xht
+    status: FAIL
+  - test: sizing-orthog-vrl-in-htb-004.xht
+    status: FAIL
+  - test: sizing-orthog-vrl-in-htb-008.xht
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-001.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-002.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-003.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-004.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-005.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-006.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-007.html
+    status: FAIL
+  - test: sizing-orthogonal-percentage-margin-008.html
+    status: FAIL
+  - test: sizing-percentages-replaced-orthogonal-001.html
+    status: FAIL
+  - test: table-cell-001.html
+    status: FAIL
+  - test: table-cell-002.html
+    status: FAIL
+  - test: table-column-order-002.xht
+    status: FAIL
+  - test: table-column-order-003.xht
+    status: FAIL
+  - test: table-column-order-004.xht
+    status: FAIL
+  - test: table-column-order-005.xht
+    status: FAIL
+  - test: table-column-order-slr-007.xht
+    status: FAIL
+  - test: table-column-order-srl-006.xht
+    status: FAIL
+  - test: table-progression-slr-001.html
+    status: FAIL
+  - test: table-progression-slr-002.html
+    status: FAIL
+  - test: table-progression-srl-001.html
+    status: FAIL
+  - test: table-progression-srl-002.html
+    status: FAIL
+  - test: table-progression-vlr-001.html
+    status: FAIL
+  - test: table-progression-vlr-003.html
+    status: FAIL
+  - test: table-progression-vlr-004.html
+    status: FAIL
+  - test: table-progression-vrl-001.html
+    status: FAIL
+  - test: table-progression-vrl-003.html
+    status: FAIL
+  - test: table-progression-vrl-004.html
+    status: FAIL
+  - test: text-baseline-slr-009.xht
+    status: FAIL
+  - test: text-baseline-srl-008.xht
+    status: FAIL
+  - test: text-combine-upright-layout-rules-001.html
+    status: FAIL
+  - test: text-combine-upright-line-breaking-rules-001.html
+    status: FAIL
+  - test: text-combine-upright-value-all-001.html
+    status: FAIL
+  - test: text-combine-upright-value-all-002.html
+    status: FAIL
+  - test: text-combine-upright-value-all-003.html
+    status: FAIL
+  - test: text-combine-upright-value-digits2-001.html
+    status: FAIL
+  - test: text-combine-upright-value-digits2-002.html
+    status: FAIL
+  - test: text-combine-upright-value-digits3-001.html
+    status: FAIL
+  - test: text-combine-upright-value-digits3-002.html
+    status: FAIL
+  - test: text-combine-upright-value-digits4-001.html
+    status: FAIL
+  - test: text-combine-upright-value-digits4-002.html
+    status: FAIL
+  - test: text-orientation-mixed-srl-016.xht
+    status: FAIL
+  - test: text-orientation-mixed-vlr-100.html
+    status: FAIL
+  - test: text-orientation-mixed-vrl-100.html
+    status: FAIL
+  - test: text-orientation-sideways-vlr-100.html
+    status: FAIL
+  - test: text-orientation-sideways-vrl-100.html
+    status: FAIL
+  - test: text-orientation-upright-srl-018.xht
+    status: FAIL
+  - test: text-orientation-upright-vlr-100.html
+    status: FAIL
+  - test: text-orientation-upright-vrl-100.html
+    status: FAIL
+  - test: three-levels-of-orthogonal-flows.html
+    status: FAIL
+  - test: two-levels-of-orthogonal-flows-fixed.html
+    status: FAIL
+  - test: two-levels-of-orthogonal-flows-percentage.html
+    status: FAIL
+  - test: two-levels-of-orthogonal-flows.html
+    status: FAIL
+  - test: vertical-alignment-003.xht
+    status: FAIL
+  - test: vertical-alignment-009.xht
+    status: FAIL
+  - test: vertical-alignment-slr-029.xht
+    status: FAIL
+  - test: vertical-alignment-slr-031.xht
+    status: FAIL
+  - test: vertical-alignment-slr-033.xht
+    status: FAIL
+  - test: vertical-alignment-slr-035.xht
+    status: FAIL
+  - test: vertical-alignment-slr-041.xht
+    status: FAIL
+  - test: vertical-alignment-srl-028.xht
+    status: FAIL
+  - test: vertical-alignment-srl-030.xht
+    status: FAIL
+  - test: vertical-alignment-srl-032.xht
+    status: FAIL
+  - test: vertical-alignment-srl-034.xht
+    status: FAIL
+  - test: vertical-alignment-srl-040.xht
+    status: FAIL

--- a/custom-elements/parser/META.yml
+++ b/custom-elements/parser/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: parser-uses-create-an-element-for-a-token-svg.svg
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=187800
+  results:
+  - test: parser-uses-create-an-element-for-a-token-svg.svg
+    status: FAIL

--- a/custom-elements/parser/META.yml
+++ b/custom-elements/parser/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=187800
+  results:
+  - test: parser-uses-create-an-element-for-a-token-svg.svg
+    status: FAIL

--- a/dom/events/META.yml
+++ b/dom/events/META.yml
@@ -11,3 +11,13 @@ links:
     subtest: 'throws if `handleEvent` is falsy and not callable'
   - test: EventListener-handleEvent.html
     subtest: 'throws if `handleEvent` is thruthy and not callable'
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=177447
+  results:
+  - test: Event-timestamp-high-resolution.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=153707
+  results:
+  - test: EventTarget-dispatchEvent.html
+    status: FAIL

--- a/encrypted-media/META.yml
+++ b/encrypted-media/META.yml
@@ -3,3 +3,7 @@ links:
   url: https://bugs.webkit.org/show_bug.cgi?id=158836
   results:
   - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=190991
+  results:
+  - test: "*"

--- a/encrypted-media/META.yml
+++ b/encrypted-media/META.yml
@@ -1,0 +1,5 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=158836
+  results:
+  - test: "*"

--- a/fetch/api/headers/META.yml
+++ b/fetch/api/headers/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186618
+  results:
+  - test: header-values.html
+    status: FAIL

--- a/fetch/http-cache/META.yml
+++ b/fetch/http-cache/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=193322
+  results:
+  - test: cc-request.html
+    status: FAIL

--- a/fetch/stale-while-revalidate/META.yml
+++ b/fetch/stale-while-revalidate/META.yml
@@ -1,0 +1,5 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206416
+  results:
+  - test: "*"

--- a/html/browsers/history/the-location-interface/META.yml
+++ b/html/browsers/history/the-location-interface/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=197709
+  results:
+  - test: location_hash.html
+    status: FAIL

--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/META.yml
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/META.yml
@@ -1,0 +1,20 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=195670
+  results:
+  - test: load-events-networkState.html
+    status: TIMEOUT
+  - test: resource-selection-pointer-control.html
+    status: FAIL
+  - test: resource-selection-pointer-insert-br.html
+    status: FAIL
+  - test: resource-selection-pointer-insert-source.html
+    status: FAIL
+  - test: resource-selection-pointer-insert-text.html
+    status: FAIL
+  - test: resource-selection-pointer-remove-source-after.html
+    status: FAIL
+  - test: resource-selection-pointer-remove-source.html
+    status: FAIL
+  - test: resource-selection-pointer-remove-text.html
+    status: FAIL

--- a/html/semantics/embedded-content/the-img-element/META.yml
+++ b/html/semantics/embedded-content/the-img-element/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=196698
+  results:
+  - test: iframe-loading-lazy.html
+    status: FAIL

--- a/html/semantics/embedded-content/the-img-element/META.yml
+++ b/html/semantics/embedded-content/the-img-element/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: iframe-loading-lazy.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=196698
+  results:
+  - test: iframe-loading-lazy.html
+    status: FAIL

--- a/html/semantics/embedded-content/the-img-element/sizes/META.yml
+++ b/html/semantics/embedded-content/the-img-element/sizes/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=208633
+  results:
+  - test: parse-a-sizes-attribute-width-1000px.html
+    status: FAIL

--- a/html/semantics/embedded-content/the-video-element/META.yml
+++ b/html/semantics/embedded-content/the-video-element/META.yml
@@ -9,3 +9,8 @@ links:
   results:
   - test: video_initially_paused.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206657
+  results:
+  - test: resize-during-playback.html
+    status: TIMEOUT

--- a/html/semantics/forms/textfieldselection/META.yml
+++ b/html/semantics/forms/textfieldselection/META.yml
@@ -1,0 +1,16 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=207624
+  results:
+  - test: textfieldselection-setSelectionRange.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=173413
+  results:
+  - test: selection-after-content-change.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=184776
+  results:
+  - test: selection-not-application.html
+    status: FAIL

--- a/html/semantics/forms/the-input-element/META.yml
+++ b/html/semantics/forms/the-input-element/META.yml
@@ -7,3 +7,8 @@ links:
   url: https://bugs.webkit.org/show_bug.cgi?id=119175
   results:
   - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=180645
+  results:
+  - test: type-change-state.html
+    status: FAIL

--- a/html/semantics/scripting-1/the-script-element/execution-timing/META.yml
+++ b/html/semantics/scripting-1/the-script-element/execution-timing/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=208104
+  results:
+  - test: 085.html
+    status: FAIL

--- a/infrastructure/testdriver/META.yml
+++ b/infrastructure/testdriver/META.yml
@@ -3,3 +3,7 @@ links:
   url: https://bugs.webkit.org/show_bug.cgi?id=187039
   results:
   - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=187039
+  results:
+  - test: "*"

--- a/infrastructure/testdriver/META.yml
+++ b/infrastructure/testdriver/META.yml
@@ -1,0 +1,5 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=187039
+  results:
+  - test: "*"

--- a/intersection-observer/v2/META.yml
+++ b/intersection-observer/v2/META.yml
@@ -1,0 +1,8 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=208052
+  results:
+  - test: cross-origin-effects.sub.html
+    status: FAIL
+  - test: cross-origin-occlusion.sub.html
+    status: FAIL

--- a/intersection-observer/v2/META.yml
+++ b/intersection-observer/v2/META.yml
@@ -6,3 +6,10 @@ links:
     status: FAIL
   - test: cross-origin-occlusion.sub.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=208052
+  results:
+  - test: cross-origin-effects.sub.html
+    status: FAIL
+  - test: cross-origin-occlusion.sub.html
+    status: FAIL

--- a/media-source/META.yml
+++ b/media-source/META.yml
@@ -1,14 +1,4 @@
 links:
-- product: webkitgtk
-  url: https://bugs.webkit.org/show_bug.cgi?id=167108
-  results:
-  - test: mediasource-sourcebuffer-mode-timestamps.html
-    status: TIMEOUT
-- product: webkitgtk
-  url: https://bugs.webkit.org/show_bug.cgi?id=203078
-  results:
-  - test: mediasource-seek-beyond-duration.html
-    status: TIMEOUT
 - product: safari
   url: https://bugs.webkit.org/show_bug.cgi?id=161725
   results:
@@ -70,6 +60,8 @@ links:
     status: FAIL
   - test: mediasource-sequencemode-append-buffer.html
     status: FAIL
+  - test: mediasource-sourcebuffer-mode-timestamps.html
+    status: TIMEOUT
   - test: mediasource-trackdefaultlist.html
     status: FAIL
 - product: webkitgtk

--- a/media-source/META.yml
+++ b/media-source/META.yml
@@ -9,3 +9,37 @@ links:
   results:
   - test: mediasource-seek-beyond-duration.html
     status: TIMEOUT
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=161725
+  results:
+  - test: URL-createObjectURL-revoke.html
+    status: FAIL
+  - test: mediasource-append-buffer.html
+    status: FAIL
+  - test: mediasource-appendbuffer-quota-exceeded.html
+    status: TIMEOUT
+  - test: mediasource-config-change-mp4-av-framesize.html
+    status: TIMEOUT
+  - test: mediasource-endofstream.html
+    status: TIMEOUT
+  - test: mediasource-errors.html
+    status: FAIL
+  - test: mediasource-is-type-supported.html
+    status: FAIL
+  - test: mediasource-seek-beyond-duration.html
+    status: FAIL
+  - test: mediasource-seek-during-pending-seek.html
+    status: FAIL
+  - test: mediasource-sequencemode-append-buffer.html
+    status: FAIL
+  - test: mediasource-sourcebuffer-mode-timestamps.html
+    status: FAIL
+  - test: mediasource-sourcebuffer-mode.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=153588
+  results:
+  - test: mediasource-correct-frames-after-reappend.html
+    status: TIMEOUT
+  - test: mediasource-correct-frames.html
+    status: TIMEOUT

--- a/media-source/META.yml
+++ b/media-source/META.yml
@@ -43,3 +43,47 @@ links:
     status: TIMEOUT
   - test: mediasource-correct-frames.html
     status: TIMEOUT
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=167108
+  results:
+  - test: URL-createObjectURL-revoke.html
+    status: FAIL
+  - test: mediasource-activesourcebuffers.html
+    status: TIMEOUT
+  - test: mediasource-append-buffer.html
+    status: FAIL
+  - test: mediasource-avtracks.html
+    status: FAIL
+  - test: mediasource-buffered.html
+    status: FAIL
+  - test: mediasource-changetype.html
+    status: FAIL
+  - test: mediasource-duration.html
+    status: FAIL
+  - test: mediasource-endofstream.html
+    status: FAIL
+  - test: mediasource-errors.html
+    status: FAIL
+  - test: mediasource-preload.html
+    status: TIMEOUT
+  - test: mediasource-seekable.html
+    status: FAIL
+  - test: mediasource-sequencemode-append-buffer.html
+    status: FAIL
+  - test: mediasource-trackdefaultlist.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210342
+  results:
+  - test: mediasource-sourcebuffer-trackdefaults.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=210498
+  results:
+  - test: mediasource-trackdefault.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=180803
+  results:
+  - test: mediasource-duration-boundaryconditions.html
+    status: FAIL

--- a/mediacapture-fromelement/META.yml
+++ b/mediacapture-fromelement/META.yml
@@ -3,3 +3,8 @@ links:
   url: https://bugs.chromium.org/p/chromium/issues/detail?id=983621
   results:
   - test: historical.html
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=179356
+  results:
+  - test: capture.html
+    status: FAIL

--- a/mediacapture-streams/META.yml
+++ b/mediacapture-streams/META.yml
@@ -28,3 +28,17 @@ links:
     subtest: 'Feature policy "microphone" can be enabled in cross-origin iframes using "allow" attribute.'
   - test: MediaStream-default-feature-policy.https.html
     subtest: 'Feature policy "camera" can be enabled in cross-origin iframes using "allow" attribute.'
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206656
+  results:
+  - test: MediaStream-removetrack.https.html
+    status: FAIL
+  - test: MediaStreamTrack-MediaElement-disabled-video-is-black.https.html
+    status: FAIL
+  - test: MediaStreamTrack-getSettings.https.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=189995
+  results:
+  - test: MediaStream-MediaElement-srcObject.https.html
+    status: FAIL

--- a/offscreen-canvas/META.yml
+++ b/offscreen-canvas/META.yml
@@ -1,0 +1,9 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=183720
+  results:
+  - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=183720
+  results:
+  - test: "*"

--- a/offscreen-canvas/text/META.yml
+++ b/offscreen-canvas/text/META.yml
@@ -4,3 +4,7 @@ links:
   results:
   - test: 2d.text.measure.width.space.html
   - test: 2d.text.measure.width.space.worker.html
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=186759
+  results:
+  - test: "*"

--- a/payment-request/allowpaymentrequest/META.yml
+++ b/payment-request/allowpaymentrequest/META.yml
@@ -1,0 +1,10 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=175611
+  results:
+  - test: allowpaymentrequest-attribute-cross-origin-bc-containers.https.html
+    status: FAIL
+  - test: removing-allowpaymentrequest.https.sub.html
+    status: FAIL
+  - test: setting-allowpaymentrequest.https.sub.html
+    status: FAIL

--- a/picture-in-picture/META.yml
+++ b/picture-in-picture/META.yml
@@ -3,3 +3,7 @@ links:
   url: https://bugs.webkit.org/show_bug.cgi?id=202617
   results:
   - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=202617
+  results:
+  - test: "*"

--- a/picture-in-picture/META.yml
+++ b/picture-in-picture/META.yml
@@ -1,9 +1,9 @@
 links:
 - product: safari
-  url: https://bugs.webkit.org/show_bug.cgi?id=202617
+  url: https://bugs.webkit.org/show_bug.cgi?id=182688
   results:
   - test: "*"
 - product: webkitgtk
-  url: https://bugs.webkit.org/show_bug.cgi?id=202617
+  url: https://bugs.webkit.org/show_bug.cgi?id=182688
   results:
   - test: "*"

--- a/picture-in-picture/META.yml
+++ b/picture-in-picture/META.yml
@@ -1,0 +1,5 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=202617
+  results:
+  - test: "*"

--- a/remote-playback/META.yml
+++ b/remote-playback/META.yml
@@ -1,0 +1,14 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206528
+  results:
+  - test: cancel-watch-availability.html
+    status: FAIL
+  - test: disable-remote-playback-cancel-watch-availability-throws.html
+    status: FAIL
+  - test: disable-remote-playback-prompt-throws.html
+    status: FAIL
+  - test: disable-remote-playback-watch-availability-throws.html
+    status: FAIL
+  - test: watch-availability-initial-callback.html
+    status: FAIL

--- a/resource-timing/META.yml
+++ b/resource-timing/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=197473
+  results:
+  - test: resource-timing-level1.sub.html
+    status: FAIL

--- a/service-workers/service-worker/META.yml
+++ b/service-workers/service-worker/META.yml
@@ -22,3 +22,18 @@ links:
   results:
   - test: fetch-canvas-tainting-video-with-range-request.https.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=175419
+  results:
+  - test: registration-script.https.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=201665
+  results:
+  - test: fetch-canvas-tainting-video.https.html
+    status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=201666
+  results:
+  - test: fetch-canvas-tainting-video-with-range-request.https.html
+    status: TIMEOUT

--- a/service-workers/service-worker/META.yml
+++ b/service-workers/service-worker/META.yml
@@ -7,3 +7,18 @@ links:
   results:
   - test: fetch-request-css-images.https.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1532331
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=182176
+  results:
+  - test: appcache-ordering-main.https.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=201665
+  results:
+  - test: fetch-canvas-tainting-video.https.html
+    status: FAIL
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=201666
+  results:
+  - test: fetch-canvas-tainting-video-with-range-request.https.html
+    status: FAIL

--- a/svg/extensibility/foreignObject/META.yml
+++ b/svg/extensibility/foreignObject/META.yml
@@ -31,3 +31,8 @@ links:
     status: FAIL
   - test: compositing-backface-visibility.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=205998
+  results:
+  - test: masked.html
+    status: FAIL

--- a/url/META.yml
+++ b/url/META.yml
@@ -1,0 +1,12 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=207678
+  results:
+  - test: a-element-origin-xhtml.xhtml
+    status: FAIL
+  - test: a-element-origin.html
+    status: FAIL
+  - test: a-element-xhtml.xhtml
+    status: FAIL
+  - test: a-element.html
+    status: FAIL

--- a/web-animations/timing-model/animations/META.yml
+++ b/web-animations/timing-model/animations/META.yml
@@ -1,0 +1,8 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=207260
+  results:
+  - test: update-playback-rate-slow.html
+    status: FAIL
+  - test: update-playback-rate-zero.html
+    status: FAIL

--- a/web-animations/timing-model/animations/META.yml
+++ b/web-animations/timing-model/animations/META.yml
@@ -6,3 +6,8 @@ links:
     status: FAIL
   - test: update-playback-rate-zero.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=207260
+  results:
+  - test: reverse-running-animation.html
+    status: FAIL

--- a/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/META.yml
+++ b/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=184777
+  results:
+  - test: mediaElementAudioSourceToScriptProcessorTest.html
+    status: FAIL

--- a/webmessaging/broadcastchannel/META.yml
+++ b/webmessaging/broadcastchannel/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=161472
+  results:
+  - test: workers.html
+    status: FAIL

--- a/webmessaging/broadcastchannel/META.yml
+++ b/webmessaging/broadcastchannel/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: workers.html
     status: FAIL
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=161472
+  results:
+  - test: workers.html
+    status: FAIL

--- a/webrtc/META.yml
+++ b/webrtc/META.yml
@@ -9,3 +9,8 @@ links:
   results:
   - test: RTCRtpReceiver-getSynchronizationSources.https.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1525394
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=172521
+  results:
+  - test: getstats.html
+    status: TIMEOUT

--- a/websockets/constructor/META.yml
+++ b/websockets/constructor/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206652
+  results:
+  - test: 011.html
+    status: FAIL

--- a/websockets/interfaces/WebSocket/bufferedAmount/META.yml
+++ b/websockets/interfaces/WebSocket/bufferedAmount/META.yml
@@ -1,0 +1,6 @@
+links:
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=206652
+  results:
+  - test: bufferedAmount-getting.html
+    status: FAIL

--- a/webxr/META.yml
+++ b/webxr/META.yml
@@ -3,3 +3,7 @@ links:
   url: https://bugs.webkit.org/show_bug.cgi?id=208988
   results:
   - test: "*"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=208988
+  results:
+  - test: "*"

--- a/webxr/META.yml
+++ b/webxr/META.yml
@@ -1,0 +1,5 @@
+links:
+- product: safari
+  url: https://bugs.webkit.org/show_bug.cgi?id=208988
+  results:
+  - test: "*"

--- a/xhr/META.yml
+++ b/xhr/META.yml
@@ -4,3 +4,8 @@ links:
   results:
   - test: setrequestheader-header-allowed.htm
     subtest: "XMLHttpRequest: setRequestHeader() - headers that are allowed (User-Agent)"
+- product: webkitgtk
+  url: https://bugs.webkit.org/show_bug.cgi?id=209801
+  results:
+  - test: header-user-agent-sync.htm
+    status: FAIL


### PR DESCRIPTION
This PR adds new metadatafa updates for both Safari and WebKitGTK.
* It is a sync from the info contained on the WebKit TestExpectation files (it adds around 500 new known failures). The sync has been curated to only contain info for tests that are currently failing on wpt.fyi and where the bug pointed at bugs.webkit.org is still open.
* The PR also contais a few manual metadata updates