### PR TITLE
Enable automerge for all META.yml files

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,6 @@ jobs:
         # https://github.com/pascalgn/automerge-action#configuration
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: ""
+          MERGE_LABELS: "!do not merge yet"
           MERGE_FORKS: false
-          MERGE_FILTER_AUTHOR: "wptfyibot"
           MERGE_METHOD: "rebase"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Prevent non-META.yml files from being automatically merged.
+!META.yml @kyleju


### PR DESCRIPTION
Fix for #172. In addition,  this PR enables auto-merge for all META.yml files regardless of authors.

As a result of this PR, changes that only contain META.yml files from a non-fork will be merged automatically, regardless of authors, unless a `do not merge yet` label is present. 