### PR TITLE
Handle removal of css/css-pseudo/selection-text-shadow-016.html

### DIFF
--- a/css/css-pseudo/META.yml
+++ b/css/css-pseudo/META.yml
@@ -64,11 +64,6 @@ links:
   - status: FAIL
     test: active-selection-056.html
   url: crbug.com/1018465
-- product: chrome
-  results:
-  - status: FAIL
-    test: selection-text-shadow-016.html
-  url: crbug.com/932343
 - product: firefox
   results:
   - test: marker-text-transform-default.html


### PR DESCRIPTION
This test was removed in 9d3e9615ee9db69e2feadd8a840431749c80df87 and
not clearly replaced by anything, so just remove the metadata.

This will unblock https://github.com/web-platform-tests/wpt-metadata/pull/748