### PR TITLE
Fix all bug URLs to start with https://

### DIFF
--- a/WebIDL/ecmascript-binding/META.yml
+++ b/WebIDL/ecmascript-binding/META.yml
@@ -8,12 +8,12 @@ links:
   - test: iterator-prototype-object.html
   - test: class-string-iterator-prototype-object.any.html
 - product: chrome
-  url: crbug.com/947523
+  url: https://crbug.com/947523
   results:
   - test: constructors.html
     status: FAIL
 - product: chrome
-  url: crbug.com/715122
+  url: https://crbug.com/715122
   results:
   - test: sequence-conversion.html
     status: FAIL

--- a/beacon/headers/META.yml
+++ b/beacon/headers/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/876671
+  url: https://crbug.com/876671
   results:
   - test: header-content-type-and-body.html
     status: FAIL

--- a/content-security-policy/connect-src/META.yml
+++ b/content-security-policy/connect-src/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/651742
+  url: https://crbug.com/651742
   results:
   - test: worker-connect-src-blocked.sub.html
     status: FAIL

--- a/cors/META.yml
+++ b/cors/META.yml
@@ -5,12 +5,12 @@ links:
   - test: origin.htm
     status: FAIL
 - product: chrome
-  url: crbug.com/651743
+  url: https://crbug.com/651743
   results:
   - test: preflight-cache.htm
     status: FAIL
 - product: chrome
-  url: crbug.com/978146
+  url: https://crbug.com/978146
   results:
   - test: access-control-expose-headers-parsing.window.html
     status: FAIL

--- a/css/compositing/mix-blend-mode/META.yml
+++ b/css/compositing/mix-blend-mode/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/1044742
+  url: https://crbug.com/1044742
   results:
   - test: mix-blend-mode-canvas-parent.html
     status: FAIL

--- a/css/css-align/baseline-rules/META.yml
+++ b/css/css-align/baseline-rules/META.yml
@@ -1,5 +1,5 @@
 links:
 - product: chrome
-  url: crbug.com/799016
+  url: https://crbug.com/799016
   results:
   - test: synthesized-baseline-table-cell-001.html

--- a/css/css-animations/META.yml
+++ b/css/css-animations/META.yml
@@ -9,7 +9,7 @@ links:
   - test: Document-getAnimations.tentative.html
     subtest: CSS Animations targetting (pseudo-)elements should have correct order after sorting (::marker)
 - product: chrome
-  url: crbug.com/868224
+  url: https://crbug.com/868224
   results:
   - test: idlharness.html
     status: FAIL

--- a/css/css-animations/parsing/META.yml
+++ b/css/css-animations/parsing/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/882285
+  url: https://crbug.com/882285
   results:
   - test: animation-name-invalid.html
     status: FAIL

--- a/css/css-backgrounds/META.yml
+++ b/css/css-backgrounds/META.yml
@@ -93,7 +93,7 @@ links:
   results:
   - test: css-border-radius-001.html
 - product: chrome
-  url: crbug.com/767352
+  url: https://crbug.com/767352
   results:
   - test: border-image-width-008.html
 - product: firefox

--- a/css/css-backgrounds/animations/META.yml
+++ b/css/css-backgrounds/animations/META.yml
@@ -3,7 +3,7 @@ links:
   results:
   - status: FAIL
     test: background-image-interpolation.html
-  url: crbug.com/1029529
+  url: https://crbug.com/1029529
 - product: firefox
   results:
   - subtest: 'CSS Transitions: property <background-image> from neutral to [url(../resources/green-100.png)]

--- a/css/css-backgrounds/background-size/META.yml
+++ b/css/css-backgrounds/background-size/META.yml
@@ -5,7 +5,7 @@ links:
   - test: background-size-contain.xht
     status: FAIL
 - product: chrome
-  url: crbug.com/1042783
+  url: https://crbug.com/1042783
   results:
   - test: background-size-near-zero-svg.html
   - test: background-size-near-zero-png.html

--- a/css/css-break/META.yml
+++ b/css/css-break/META.yml
@@ -34,7 +34,7 @@ links:
   - test: fieldset-003.html
   - test: overflowed-block-with-no-room-after-000.html
   - test: tall-line-in-short-fragmentainer-000.html
-  url: crbug.com/829028
+  url: https://crbug.com/829028
 - product: firefox
   results:
   - subtest: Below line4

--- a/css/css-color-adjust/rendering/dark-color-scheme/META.yml
+++ b/css/css-color-adjust/rendering/dark-color-scheme/META.yml
@@ -5,6 +5,6 @@ links:
   - test: color-scheme-change-checkbox.html
   - test: color-scheme-visited-link-initial.html
 - product: chrome
-  url: crbug.com/929098
+  url: https://crbug.com/929098
   results:
   - test: color-scheme-change-checkbox.html

--- a/css/css-color/META.yml
+++ b/css/css-color/META.yml
@@ -5,7 +5,7 @@ links:
   - test: t425-hsla-clip-outside-device-gamut-b.xht
     status: FAIL
 - product: chrome
-  url: crbug.com/1068610
+  url: https://crbug.com/1068610
   results:
   - test: predefined-002.html
   - test: predefined-005.html

--- a/css/css-contain/META.yml
+++ b/css/css-contain/META.yml
@@ -31,12 +31,12 @@ links:
       results:
         - test: '*'
     - product: chrome
-      url: crbug.com/847274
+      url: https://crbug.com/847274
       results:
         - test: contain-paint-005.html
         - test: contain-paint-006.html
     - product: chrome
-      url: crbug.com/882385
+      url: https://crbug.com/882385
       results:
         - test: quote-scoping-001.html
         - test: quote-scoping-002.html

--- a/css/css-content/META.yml
+++ b/css/css-content/META.yml
@@ -1,12 +1,12 @@
 links:
 - product: chrome
-  url: crbug.com/753671
+  url: https://crbug.com/753671
   results:
   - test: quotes-021.html
   - test: quotes-001.html
   - test: quotes-013.html
   - test: quotes-022.html
 - product: chrome
-  url: crbug.com/1067277
+  url: https://crbug.com/1067277
   results:
   - test: element-replacement-on-replaced-element.tentative.html

--- a/css/css-display/META.yml
+++ b/css/css-display/META.yml
@@ -39,14 +39,14 @@ links:
   - test: display-math-on-pseudo-elements-001.html
     subtest: computed display on ::before and ::after for <mrow class="block">
 - product: chrome
-  url: crbug.com/1127222
+  url: https://crbug.com/1127222
   results:
   - test: display-math-on-pseudo-elements-001.html
 - product: chrome
-  url: crbug.com/181374
+  url: https://crbug.com/181374
   results:
   - test: display-contents-dynamic-table-001-inline.html
 - product: chrome
-  url: crbug.com/995106
+  url: https://crbug.com/995106
   results:
   - test: display-flow-root-list-item-001.html

--- a/css/css-flexbox/META.yml
+++ b/css/css-flexbox/META.yml
@@ -324,32 +324,32 @@ links:
         - test: flexbox-collapsed-item-horiz-002.html
         - test: flexbox-collapsed-item-horiz-003.html
     - product: chrome
-      url: crbug.com/1003506
+      url: https://crbug.com/1003506
       results:
         - test: percentage-heights-007.html
     - product: chrome
-      url: crbug.com/957454
+      url: https://crbug.com/957454
       results:
         - test: align-items-007.html
     - product: chrome
-      url: crbug.com/249112
+      url: https://crbug.com/249112
       results:
         - test: flex-minimum-height-flex-items-007.xht
         - test: flex-minimum-width-flex-items-007.xht
     - product: chrome
-      url: crbug.com/1128262
+      url: https://crbug.com/1128262
       results:
         - test: table-as-item-specified-width.html
     - product: chrome
-      url: crbug.com/1111708
+      url: https://crbug.com/1111708
       results:
         - test: flexbox_justifycontent-center-overflow.html
     - product: chrome
-      url: crbug.com/807497
+      url: https://crbug.com/807497
       results:
         - test: anonymous-flex-item-005.html
     - product: chrome
-      url: crbug.com/1081802
+      url: https://crbug.com/1081802
       results:
         - test: overflow-area-001.html
         - test: overflow-area-002.html

--- a/css/css-flexbox/abspos/META.yml
+++ b/css/css-flexbox/abspos/META.yml
@@ -104,7 +104,7 @@ links:
         - test: position-absolute-013.html
           subtest: .flexbox 129
     - product: chrome
-      url: crbug.com/845235
+      url: https://crbug.com/845235
       results:
         - test: position-absolute-012.html
           status: FAIL

--- a/css/css-flexbox/parsing/META.yml
+++ b/css/css-flexbox/parsing/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/988583
+  url: https://crbug.com/988583
   results:
   - test: flex-basis-computed.html
     status: FAIL

--- a/css/css-font-loading/META.yml
+++ b/css/css-font-loading/META.yml
@@ -17,12 +17,12 @@ links:
   results:
   - status: FAIL
     test: fontface-descriptor-updates.html
-  url: crbug.com/965409
+  url: https://crbug.com/965409
 - product: chrome
   results:
   - status: FAIL
     test: idlharness.https.html
-  url: crbug.com/651795
+  url: https://crbug.com/651795
 - product: firefox
   results:
   - status: CRASH

--- a/css/css-fonts/META.yml
+++ b/css/css-fonts/META.yml
@@ -104,7 +104,7 @@ links:
   - test: idlharness.html
     subtest: 'CSSFontPaletteValuesRule interface: existence and properties of interface prototype object''s "constructor" property'
 - product: chrome
-  url: crbug.com/481430
+  url: https://crbug.com/481430
   results:
   - test: font-language-override-02.html
     status: FAIL
@@ -114,12 +114,12 @@ links:
   - test: fallback-url-to-local.html
     subtest: We should use the local font to render the page when the primary remote font is loading
 - product: chrome
-  url: crbug.com/1065468
+  url: https://crbug.com/1065468
   results:
   - test: generic-family-keywords-002.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1029069
+  url: https://crbug.com/1029069
   results:
   - test: standard-font-family-14.html
   - test: standard-font-family-15.html
@@ -130,12 +130,12 @@ links:
   - test: standard-font-family-12.html
   - test: standard-font-family-13.html
 - product: chrome
-  url: crbug.com/1058772
+  url: https://crbug.com/1058772
   results:
   - test: test-synthetic-italic-2.html
   - test: test-synthetic-italic-3.html
 - product: chrome
-  url: crbug.com/450619
+  url: https://crbug.com/450619
   results:
   - test: font-feature-resolution-001.html
   - test: font-feature-resolution-002.html

--- a/css/css-fonts/variations/META.yml
+++ b/css/css-fonts/variations/META.yml
@@ -10,7 +10,7 @@ links:
   - test: at-font-face-font-matching.html
     status: FAIL
 - product: chrome
-  url: crbug.com/809935
+  url: https://crbug.com/809935
   results:
   - test: font-style-interpolation.html
     status: TIMEOUT

--- a/css/css-grid/abspos/META.yml
+++ b/css/css-grid/abspos/META.yml
@@ -102,7 +102,7 @@ links:
   - test: positioned-grid-descendants-016.html
     status: FAIL
 - product: chrome
-  url: crbug.com/921722
+  url: https://crbug.com/921722
   results:
   - test: descendant-static-position-001.html
   - test: descendant-static-position-002.html

--- a/css/css-grid/alignment/META.yml
+++ b/css/css-grid/alignment/META.yml
@@ -126,15 +126,12 @@ links:
     - product: chrome
       url: https://crbug.com/885175
       results:
+        - test: grid-baseline-004.html
         - test: grid-self-alignment-baseline-with-grid-001.html
         - test: grid-self-alignment-baseline-with-grid-002.html
         - test: grid-self-alignment-baseline-with-grid-003.html
         - test: grid-self-alignment-baseline-with-grid-004.html
         - test: grid-item-self-baseline-001.html
-    - product: chrome
-      url: https://crbug.com/885175
-      results:
-        - test: grid-baseline-004.html
     - product: chrome
       url: https://crbug.com/1045599
       results:

--- a/css/css-grid/alignment/META.yml
+++ b/css/css-grid/alignment/META.yml
@@ -100,18 +100,18 @@ links:
         - test: grid-baseline-004.html
           subtest: .grid, container 12
     - product: chrome
-      url: crbug.com/1114013
+      url: https://crbug.com/1114013
       results:
         - test: grid-item-no-aspect-ratio-stretch-9.html
         - test: grid-item-no-aspect-ratio-stretch-10.html
         - test: grid-item-no-aspect-ratio-stretch-5.html
         - test: grid-item-no-aspect-ratio-stretch-8.html
     - product: chrome
-      url: crbug.com/941987
+      url: https://crbug.com/941987
       results:
         - test: grid-baseline-align-cycles-001.html
     - product: chrome
-      url: crbug.com/764235
+      url: https://crbug.com/764235
       results:
         - test: grid-baseline-justify-001.html
         - test: grid-item-content-baseline-001.html
@@ -124,7 +124,7 @@ links:
         - test: grid-item-mixed-baseline-001.html
         - test: grid-item-mixed-baseline-004.html
     - product: chrome
-      url: crbug.com/885175
+      url: https://crbug.com/885175
       results:
         - test: grid-self-alignment-baseline-with-grid-001.html
         - test: grid-self-alignment-baseline-with-grid-002.html
@@ -132,7 +132,7 @@ links:
         - test: grid-self-alignment-baseline-with-grid-004.html
         - test: grid-item-self-baseline-001.html
     - product: chrome
-      url: "885175"
+      url: https://crbug.com/885175
       results:
         - test: grid-baseline-004.html
     - product: chrome

--- a/css/css-grid/animation/META.yml
+++ b/css/css-grid/animation/META.yml
@@ -22,7 +22,7 @@ links:
         - test: grid-template-rows-interpolation.html
           status: FAIL
     - product: chrome
-      url: crbug.com/759665
+      url: https://crbug.com/759665
       results:
         - test: grid-template-columns-001.html
         - test: grid-template-rows-001.html

--- a/css/css-grid/animation/META.yml
+++ b/css/css-grid/animation/META.yml
@@ -25,9 +25,6 @@ links:
       url: https://crbug.com/759665
       results:
         - test: grid-template-columns-001.html
-        - test: grid-template-rows-001.html
-    - product: chrome
-      url: https://crbug.com/759665
-      results:
         - test: grid-template-columns-interpolation.html
+        - test: grid-template-rows-001.html
         - test: grid-template-rows-interpolation.html

--- a/css/css-grid/grid-definition/META.yml
+++ b/css/css-grid/grid-definition/META.yml
@@ -407,25 +407,25 @@ links:
         - test: grid-inline-template-columns-rows-resolved-values-001.html
           subtest: 'undefined ''gridAutoFlowColumnItemsPositions'' with: grid-template-columns: ; and grid-template-rows: 60px 70px;'
     - product: chrome
-      url: crbug.com/1102918
+      url: https://crbug.com/1102918
       results:
         - test: grid-auto-fill-columns-001.html
         - test: grid-auto-fill-rows-001.html
         - test: grid-auto-fit-rows-001.html
     - product: chrome
-      url: crbug.com/1103787
+      url: https://crbug.com/1103787
       results:
         - test: grid-auto-fit-columns-001.html
     - product: chrome
-      url: crbug.com/1005519
+      url: https://crbug.com/1005519
       results:
         - test: grid-auto-repeat-max-size-001.html
     - product: chrome
-      url: crbug.com/1024927
+      url: https://crbug.com/1024927
       results:
         - test: grid-inline-template-columns-rows-resolved-values-001.tentative.html
         - test: grid-template-columns-rows-resolved-values-001.tentative.html
     - product: chrome
-      url: crbug.com/1053825
+      url: https://crbug.com/1053825
       results:
         - test: grid-limits-001.html

--- a/css/css-grid/grid-model/META.yml
+++ b/css/css-grid/grid-model/META.yml
@@ -49,7 +49,7 @@ links:
   - test: grid-container-margin-border-padding-scrollbar-001.html
     subtest: .grid 14
 - product: chrome
-  url: crbug.com/1053825
+  url: https://crbug.com/1053825
   results:
   - test: grid-areas-overflowing-grid-container-002.html
   - test: grid-areas-overflowing-grid-container-001.html

--- a/css/css-grid/layout-algorithm/META.yml
+++ b/css/css-grid/layout-algorithm/META.yml
@@ -74,7 +74,7 @@ links:
         - test: grid-intrinsic-track-sizes-001.html
           subtest: '''grid'' with: grid-template-columns: max-content min-content; and grid-template-rows: max-content min-content;'
     - product: chrome
-      url: crbug.com/935102
+      url: https://crbug.com/935102
       results:
         - test: grid-flex-track-intrinsic-sizes-002.html
         - test: grid-flex-track-intrinsic-sizes-001.html
@@ -83,6 +83,6 @@ links:
       results:
         - test: flex-and-intrinsic-sizes-001.html
     - product: chrome
-      url: crbug.com/1024927
+      url: https://crbug.com/1024927
       results:
         - test: grid-flex-track-intrinsic-sizes-003.html

--- a/css/css-grid/parsing/META.yml
+++ b/css/css-grid/parsing/META.yml
@@ -45,16 +45,16 @@ links:
         - test: grid-template-columns-computed-withcontent.html
           subtest: Property grid-template-columns value 'none'
     - product: chrome
-      url: crbug.com/916827
+      url: https://crbug.com/916827
       results:
         - test: grid-area-computed.html
     - product: chrome
-      url: crbug.com/1028283
+      url: https://crbug.com/1028283
       results:
         - test: grid-shorthand-valid.html
         - test: grid-template-shorthand-valid.html
     - product: chrome
-      url: crbug.com/501673
+      url: https://crbug.com/501673
       results:
         - test: grid-shorthand.html
     - product: firefox

--- a/css/css-images/image-orientation/META.yml
+++ b/css/css-images/image-orientation/META.yml
@@ -12,12 +12,12 @@ links:
   - test: image-orientation-list-style-image.html
   - test: image-orientation-border-image.html
   - test: image-orientation-background-image.html
-  url: crbug.com/1076121
+  url: https://crbug.com/1076121
 - product: chrome
   results:
   - test: image-orientation-none-cross-origin-canvas.html
   - test: image-orientation-none-cross-origin.html
-  url: crbug.com/1110330
+  url: https://crbug.com/1110330
 - product: firefox
   results:
   - test: image-orientation-exif-png.html

--- a/css/css-images/image-resolution/META.yml
+++ b/css/css-images/image-resolution/META.yml
@@ -1,5 +1,5 @@
 links:
 - product: chrome
-  url: crbug.com/1086473
+  url: https://crbug.com/1086473
   results:
   - test: '*'

--- a/css/css-images/image-set/META.yml
+++ b/css/css-images/image-set/META.yml
@@ -1,5 +1,5 @@
 links:
 - product: chrome
-  url: crbug.com/630597
+  url: https://crbug.com/630597
   results:
   - test: image-set-rendering.html

--- a/css/css-layout-api/fallback-intrinsic-sizes/META.yml
+++ b/css/css-layout-api/fallback-intrinsic-sizes/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/726125
+  url: https://crbug.com/726125
   results:
   - test: constructor-error.https.html
     status: FAIL

--- a/css/css-lists/META.yml
+++ b/css/css-lists/META.yml
@@ -42,11 +42,11 @@ links:
   - test: li-value-reversed-005.html
   - test: li-value-reversed-004.html
   - test: li-value-reversed-003.html
-  url: crbug.com/1066577
+  url: https://crbug.com/1066577
 - product: chrome
   results:
   - test: counter-list-item-2.html
-  url: crbug.com/1123457
+  url: https://crbug.com/1123457
 - product: chrome
   results:
   - test: list-style-type-string-005b.html
@@ -55,11 +55,11 @@ links:
   - test: inline-list.html
   - test: inline-list-with-table-child.html
   - test: inline-list-marker.html
-  url: crbug.com/995106
+  url: https://crbug.com/995106
 - product: chrome
   results:
   - test: list-style-type-string-005b.html
-  url: crbug.com/1012289
+  url: https://crbug.com/1012289
 - product: firefox
   results:
   - test: list-style-image-zoom-dynamic.html

--- a/css/css-lists/animations/META.yml
+++ b/css/css-lists/animations/META.yml
@@ -3,7 +3,7 @@ links:
   results:
   - status: FAIL
     test: list-style-image-interpolation.html
-  url: crbug.com/1029358
+  url: https://crbug.com/1029358
 - product: firefox
   results:
   - subtest: 'CSS Transitions: property <list-style-image> from neutral to [url(../resources/stripes-20.png)]

--- a/css/css-logical/META.yml
+++ b/css/css-logical/META.yml
@@ -44,7 +44,7 @@ links:
   - test: animation-003.tentative.html
     status: FAIL
 - product: chrome
-  url: crbug.com/865579
+  url: https://crbug.com/865579
   results:
   - test: animation-002.html
     status: FAIL

--- a/css/css-masking/clip-path-svg-content/META.yml
+++ b/css/css-masking/clip-path-svg-content/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/843084
+  url: https://crbug.com/843084
   results:
   - test: clip-path-shape-circle-005.svg
     status: FAIL

--- a/css/css-masking/clip-path/META.yml
+++ b/css/css-masking/clip-path/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/880983
+  url: https://crbug.com/880983
   results:
   - test: clip-path-path-interpolation-001.html
     status: FAIL
@@ -11,7 +11,7 @@ links:
   - test: clip-path-path-001.html
     status: FAIL
 - product: chrome
-  url: crbug.com/843084
+  url: https://crbug.com/843084
   results:
   - test: clip-path-polygon-007.html
     status: FAIL

--- a/css/css-masking/mask-image/META.yml
+++ b/css/css-masking/mask-image/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/432153
+  url: https://crbug.com/432153
   results:
   - test: mask-image-url-image-hash.html
   - test: mask-image-url-image.html

--- a/css/css-masking/parsing/META.yml
+++ b/css/css-masking/parsing/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/843084
+  url: https://crbug.com/843084
   results:
   - test: clip-path-valid.html
     status: FAIL

--- a/css/css-multicol/META.yml
+++ b/css/css-multicol/META.yml
@@ -24,12 +24,12 @@ links:
     test: multicol-rule-inset-000.xht
   - status: FAIL
     test: multicol-rule-outset-000.xht
-  url: crbug.com/792437
+  url: https://crbug.com/792437
 - product: chrome
   results:
   - status: FAIL
     test: multicol-rule-nested-balancing-004.html
-  url: crbug.com/990240
+  url: https://crbug.com/990240
 - product: chrome
   results:
   - status: FAIL
@@ -38,7 +38,7 @@ links:
     test: multicol-span-all-fieldset-002.html
   - status: FAIL
     test: multicol-span-all-fieldset-003.html
-  url: crbug.com/874051
+  url: https://crbug.com/874051
 - product: chrome
   results:
   - status: FAIL
@@ -53,17 +53,17 @@ links:
     test: multicol-span-all-008.html
   - status: FAIL
     test: multicol-span-all-011.html
-  url: crbug.com/577282
+  url: https://crbug.com/577282
 - product: chrome
   results:
   - status: FAIL
     test: multicol-span-all-margin-bottom-001.xht
-  url: crbug.com/829028
+  url: https://crbug.com/829028
 - product: chrome
   results:
   - status: FAIL
     test: multicol-span-float-001.xht
-  url: crbug.com/792446
+  url: https://crbug.com/792446
 - product: firefox
   results:
   - test: multicol-overflow-clip-auto-sized.html
@@ -76,34 +76,34 @@ links:
   results:
   - test: columnfill-auto-max-height-001.html
   - test: columnfill-auto-max-height-002.html
-  url: crbug.com/967329
+  url: https://crbug.com/967329
 - product: chrome
   results:
   - test: multicol-breaking-004.html
   - test: multicol-breaking-nobackground-004.html
-  url: crbug.com/481431
+  url: https://crbug.com/481431
 - product: chrome
   results:
   - test: multicol-rule-004.xht
-  url: crbug.com/792435
+  url: https://crbug.com/792435
 - product: chrome
   results:
   - test: multicol-span-all-button-001.html
   - test: multicol-span-all-button-002.html
   - test: multicol-span-all-button-003.html
-  url: crbug.com/963109
+  url: https://crbug.com/963109
 - product: chrome
   results:
   - test: multicol-span-all-010.html
-  url: crbug.com/926685
+  url: https://crbug.com/926685
 - product: chrome
   results:
   - test: multicol-span-all-margin-nested-002.xht
-  url: crbug.com/636055
+  url: https://crbug.com/636055
 - product: chrome
   results:
   - test: multicol-width-005.html
-  url: crbug.com/964183
+  url: https://crbug.com/964183
 - product: firefox
   results:
   - test: balance-break-avoidance-000.html

--- a/css/css-overflow/META.yml
+++ b/css/css-overflow/META.yml
@@ -8,7 +8,7 @@ links:
   results:
   - status: FAIL
     test: overflow-codependent-scrollbars.html
-  url: crbug.com/1007065
+  url: https://crbug.com/1007065
 - product: chrome
   results:
   - test: overflow-body-propagation-007.html
@@ -19,12 +19,12 @@ links:
   results:
   - test: webkit-line-clamp-008.html
   - test: webkit-line-clamp-029.html
-  url: crbug.com/993813
+  url: https://crbug.com/993813
 - product: chrome
   results:
   - test: webkit-line-clamp-018.html
   - test: webkit-line-clamp-024.html
-  url: crbug.com/305376
+  url: https://crbug.com/305376
 - product: chrome
   results:
   - test: text-overflow-scroll-vertical-lr-001.html
@@ -33,11 +33,11 @@ links:
   - test: text-overflow-scroll-vertical-rl-rtl-001.html
   - test: text-overflow-scroll-001.html
   - test: text-overflow-scroll-rtl-001.html
-  url: crbug.com/745905
+  url: https://crbug.com/745905
 - product: chrome
   results:
   - test: webkit-line-clamp-035.html
-  url: crbug.com/1067031
+  url: https://crbug.com/1067031
 - product: firefox
   results:
   - test: overflow-clip-margin-002.html

--- a/css/css-position/META.yml
+++ b/css/css-position/META.yml
@@ -91,7 +91,7 @@ links:
       results:
         - test: position-relative-005.html
     - product: chrome
-      url: crbug.com/417223
+      url: https://crbug.com/417223
       results:
         - test: position-relative-table-tbody-left.html
         - test: position-relative-table-tbody-top-absolute-child.html

--- a/css/css-position/sticky/META.yml
+++ b/css/css-position/sticky/META.yml
@@ -70,8 +70,8 @@ links:
     test: position-sticky-table-tfoot-bottom.html
   - status: FAIL
     test: position-sticky-table-thead-top.html
-  url: crbug.com/702927
+  url: https://crbug.com/702927
 - product: chrome
   results:
   - test: position-sticky-offset-overflow.html
-  url: crbug.com/752022
+  url: https://crbug.com/752022

--- a/css/css-pseudo/META.yml
+++ b/css/css-pseudo/META.yml
@@ -63,7 +63,7 @@ links:
   results:
   - status: FAIL
     test: active-selection-056.html
-  url: crbug.com/1018465
+  url: https://crbug.com/1018465
 - product: firefox
   results:
   - test: marker-text-transform-default.html
@@ -100,33 +100,33 @@ links:
   results:
   - test: first-letter-exclude-inline-marker.html
   - test: first-letter-exclude-inline-child-marker.html
-  url: crbug.com/995106
+  url: https://crbug.com/995106
 - product: chrome
   results:
   - test: first-line-opacity-001.html
-  url: crbug.com/1085772
+  url: https://crbug.com/1085772
 - product: chrome
   results:
   - test: active-selection-063.html
-  url: crbug.com/1069300
+  url: https://crbug.com/1069300
 - product: chrome
   results:
   - test: active-selection-057.html
-  url: crbug.com/1108711
+  url: https://crbug.com/1108711
 - product: chrome
   results:
   - test: active-selection-031.html
-  url: crbug.com/1110399
+  url: https://crbug.com/1110399
 - product: chrome
   results:
   - test: active-selection-045.html
-  url: crbug.com/1110401
+  url: https://crbug.com/1110401
 - product: chrome
   results:
   - test: active-selection-025.html
   - test: active-selection-027.html
   - test: cascade-highlight-004.html
-  url: crbug.com/1024156
+  url: https://crbug.com/1024156
 - product: chrome
   results:
   - test: selection-intercharacter-012.html
@@ -135,43 +135,43 @@ links:
   - test: active-selection-012.html
   - test: active-selection-018.html
   - test: selection-intercharacter-011.html
-  url: crbug.com/1078474
+  url: https://crbug.com/1078474
 - product: chrome
   results:
   - test: file-selector-button-001.html
-  url: crbug.com/1086855
+  url: https://crbug.com/1086855
 - product: chrome
   results:
   - test: active-selection-043.html
-  url: crbug.com/1113004
+  url: https://crbug.com/1113004
 - product: chrome
   results:
   - test: selection-input-011.html
   - test: selection-textarea-011.html
-  url: crbug.com/1110495
+  url: https://crbug.com/1110495
 - product: chrome
   results:
   - test: marker-content-009.tentative.html
   - test: marker-content-011.tentative.html
   - test: marker-content-007.tentative.html
   - test: marker-content-008.tentative.html
-  url: crbug.com/1031667
+  url: https://crbug.com/1031667
 - product: chrome
   results:
   - test: marker-font-variant-numeric-normal.html
-  url: crbug.com/1097992
+  url: https://crbug.com/1097992
 - product: chrome
   results:
   - test: marker-text-combine-upright.html
-  url: crbug.com/1060007
+  url: https://crbug.com/1060007
 - product: chrome
   results:
   - test: first-line-with-out-of-flow.html
-  url: crbug.com/979253
+  url: https://crbug.com/979253
 - product: chrome
   results:
   - test: first-line-with-before-after.html
-  url: crbug.com/892983
+  url: https://crbug.com/892983
 - product: firefox
   results:
   - test: first-line-with-inline-block.html

--- a/css/css-pseudo/parsing/META.yml
+++ b/css/css-pseudo/parsing/META.yml
@@ -3,7 +3,7 @@ links:
   results:
   - status: FAIL
     test: marker-supported-properties-in-animation.html
-  url: crbug.com/1092652
+  url: https://crbug.com/1092652
 - product: firefox
   results:
   - subtest: Property animation value '1s linear 2s infinite alternate forwards paused

--- a/css/css-ruby/META.yml
+++ b/css/css-ruby/META.yml
@@ -18,7 +18,7 @@ links:
   - test: line-spacing.html
     subtest: Don't Consume half-leading of the previous line with text-emphasis
 - product: chrome
-  url: crbug.com/27659
+  url: https://crbug.com/27659
   results:
   - test: ruby-intrinsic-isize-002.html
     status: FAIL

--- a/css/css-scroll-snap/META.yml
+++ b/css/css-scroll-snap/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/954898
+  url: https://crbug.com/954898
   results:
   - test: overflowing-snap-areas.html
     status: FAIL

--- a/css/css-scroll-snap/snap-after-initial-layout/META.yml
+++ b/css/css-scroll-snap/snap-after-initial-layout/META.yml
@@ -2,7 +2,7 @@ links:
 - product: chrome
   results:
   - test: direction-rtl.html
-  url: crbug.com/1012173
+  url: https://crbug.com/1012173
 - product: firefox
   results:
   - test: writing-mode-horizontal-tb.html

--- a/css/css-scrollbars/META.yml
+++ b/css/css-scrollbars/META.yml
@@ -1,5 +1,5 @@
 links:
 - product: chrome
-  url: crbug.com/891944
+  url: https://crbug.com/891944
   results:
   - test: textarea-scrollbar-width-none.html

--- a/css/css-shapes/shape-outside/shape-image/META.yml
+++ b/css/css-shapes/shape-outside/shape-image/META.yml
@@ -46,6 +46,6 @@ links:
   - test: shape-image-024.html
     status: FAIL
 - product: chrome
-  url: crbug.com/424365
+  url: https://crbug.com/424365
   results:
   - test: shape-image-024.html

--- a/css/css-shapes/shape-outside/values/META.yml
+++ b/css/css-shapes/shape-outside/values/META.yml
@@ -11,7 +11,7 @@ links:
   - test: shape-margin-001.html
     subtest: 10vmax - computed
 - product: chrome
-  url: crbug.com/1050968
+  url: https://crbug.com/1050968
   results:
   - test: shape-outside-polygon-006.html
     status: FAIL

--- a/css/css-sizing/META.yml
+++ b/css/css-sizing/META.yml
@@ -121,6 +121,6 @@ links:
   - test: percentage-height-in-flexbox.html
     status: FAIL
 - product: chrome
-  url: crbug.com/936084
+  url: https://crbug.com/936084
   results:
   - test: max-content-input-001.html

--- a/css/css-sizing/aspect-ratio/META.yml
+++ b/css/css-sizing/aspect-ratio/META.yml
@@ -31,7 +31,7 @@ links:
   results:
   - test: flex-aspect-ratio-021.html
   - test: flex-aspect-ratio-022.html
-  url: crbug.com/470421
+  url: https://crbug.com/470421
 - product: firefox
   results:
   - test: abspos-004.html

--- a/css/css-tables/META.yml
+++ b/css/css-tables/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/377847
+  url: https://crbug.com/377847
   results:
   - test: subpixel-table-cell-height-001.html
     status: FAIL
@@ -11,12 +11,12 @@ links:
   - test: subpixel-table-width-001.html
     status: FAIL
 - product: chrome
-  url: crbug.com/764031
+  url: https://crbug.com/764031
   results:
   - test: toggle-row-display-property-001.html
     status: FAIL
 - product: chrome
-  url: crbug.com/771492
+  url: https://crbug.com/771492
   results:
   - test: table-model-fixup-2.html
     status: FAIL
@@ -32,15 +32,15 @@ links:
   - test: table-model-fixup-2.html
     subtest: Replaced elements outside a table cannot be table-row and are considered block -- img elements
 - product: chrome
-  url: crbug.com/598134
+  url: https://crbug.com/598134
   results:
   - test: table-has-box-sizing-border-box-002.html
 - product: chrome
-  url: crbug.com/694374
+  url: https://crbug.com/694374
   results:
   - test: anonymous-table-ws-001.html
 - product: chrome
-  url: crbug.com/174167
+  url: https://crbug.com/174167
   results:
   - test: visibility-collapse-col-002.html
   - test: visibility-collapse-col-003.html
@@ -54,10 +54,10 @@ links:
   - test: visibility-collapse-col-004-dynamic.html
   - test: visibility-collapse-colspan-001.html
 - product: chrome
-  url: crbug.com/613753
+  url: https://crbug.com/613753
   results:
   - test: border-spacing-included-in-sizes-001.html
 - product: chrome
-  url: crbug.com/1108224
+  url: https://crbug.com/1108224
   results:
   - test: min-max-size-table-content-box.html

--- a/css/css-tables/height-distribution/META.yml
+++ b/css/css-tables/height-distribution/META.yml
@@ -1,12 +1,12 @@
 links:
 - product: chrome
-  url: crbug.com/708345
+  url: https://crbug.com/708345
   results:
   - test: extra-height-given-to-all-row-groups-001.html
   - test: extra-height-given-to-all-row-groups-003.html
   - test: extra-height-given-to-all-row-groups-004.html
   - test: extra-height-given-to-all-row-groups-005.html
 - product: chrome
-  url: crbug.com/353580
+  url: https://crbug.com/353580
   results:
   - test: percentage-sizing-of-table-cell-children-005.html

--- a/css/css-tables/tentative/META.yml
+++ b/css/css-tables/tentative/META.yml
@@ -29,7 +29,7 @@ links:
   results:
   - status: FAIL
     test: colspan-redistribution.html
-  url: crbug.com/958381
+  url: https://crbug.com/958381
 - product: firefox
   results:
   - subtest: table 14

--- a/css/css-text-decor/META.yml
+++ b/css/css-text-decor/META.yml
@@ -68,7 +68,7 @@ links:
   results:
   - test: text-decoration-thickness-from-font-variable.html
 - product: chrome
-  url: crbug.com/785230
+  url: https://crbug.com/785230
   results:
   - test: text-decoration-shorthands-001.html
     status: FAIL
@@ -81,13 +81,13 @@ links:
   results:
   - test: text-decoration-color.html
 - product: chrome
-  url: ' crbug.com/1008951'
+  url: https://crbug.com/1008951
   results:
   - test: text-decoration-subelements-003.html
   - test: text-decoration-color.html
   - test: text-decoration-subelements-002.html
 - product: chrome
-  url: crbug.com/666433
+  url: https://crbug.com/666433
   results:
   - test: text-emphasis-position-above-right-001.xht
   - test: text-emphasis-style-006.html
@@ -110,11 +110,11 @@ links:
   - test: text-emphasis-position-below-left-002.xht
   - test: text-emphasis-style-shape-001.xht
 - product: chrome
-  url: crbug.com/1054656
+  url: https://crbug.com/1054656
   results:
   - test: text-decoration-skip-ink-005.html
 - product: chrome
-  url: crbug.com/1133806
+  url: https://crbug.com/1133806
   results:
   - test: text-underline-offset-vertical-002.html
   - test: text-decoration-skip-ink-upright-001.html

--- a/css/css-text-decor/parsing/META.yml
+++ b/css/css-text-decor/parsing/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/1067242
+  url: https://crbug.com/1067242
   results:
   - test: text-underline-position-computed.html
     status: FAIL

--- a/css/css-text/boundary-shaping/META.yml
+++ b/css/css-text/boundary-shaping/META.yml
@@ -26,7 +26,7 @@ links:
   - test: boundary-shaping-010.html
     status: FAIL
 - product: chrome
-  url: crbug.com/591099
+  url: https://crbug.com/591099
   results:
   - test: boundary-shaping-009.html
     status: FAIL

--- a/css/css-text/hyphens/META.yml
+++ b/css/css-text/hyphens/META.yml
@@ -1,25 +1,25 @@
 links:
     - product: chrome
-      url: crbug.com/591099
+      url: https://crbug.com/591099
       results:
         - test: shy-styling-001.html
           status: FAIL
         - test: hyphens-out-of-flow-002.html
     - product: chrome
-      url: crbug.com/958672
+      url: https://crbug.com/958672
       results:
         - test: hyphens-shaping-002.html
           status: FAIL
     - product: chrome
-      url: crbug.com/652964
+      url: https://crbug.com/652964
       results:
         - test: hyphens-auto-010.html
         - test: hyphens-auto-inline-010.html
     - product: chrome
-      url: crbug.com/963369
+      url: https://crbug.com/963369
       results:
         - test: hyphens-out-of-flow-001.html
     - product: chrome
-      url: crbug.com/1140728
+      url: https://crbug.com/1140728
       results:
         - test: hyphens-span-002.html

--- a/css/css-text/line-break/META.yml
+++ b/css/css-text/line-break/META.yml
@@ -61,13 +61,13 @@ links:
   - test: line-break-normal-013.xht
     status: FAIL
 - product: chrome
-  url: crbug.com/1052717
+  url: https://crbug.com/1052717
   results:
   - test: line-break-strict-hyphens-002.html
   - test: line-break-loose-hyphens-001.html
   - test: line-break-normal-hyphens-002.html
 - product: chrome
-  url: crbug.com/1091631
+  url: https://crbug.com/1091631
   results:
   - test: line-break-normal-015a.xht
   - test: line-break-strict-015a.xht

--- a/css/css-text/line-breaking/META.yml
+++ b/css/css-text/line-breaking/META.yml
@@ -38,7 +38,7 @@ links:
   - test: line-breaking-ic-003.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1024331
+  url: https://crbug.com/1024331
   results:
   - test: line-breaking-018.html
     status: FAIL

--- a/css/css-text/overflow-wrap/META.yml
+++ b/css/css-text/overflow-wrap/META.yml
@@ -39,7 +39,7 @@ links:
   - test: overflow-wrap-min-content-size-003.html
     status: FAIL
 - product: chrome
-  url: crbug.com/964181
+  url: https://crbug.com/964181
   results:
   - test: overflow-wrap-anywhere-inline-003.html
   - test: overflow-wrap-anywhere-inline-002.html

--- a/css/css-text/shaping/META.yml
+++ b/css/css-text/shaping/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/591099
+  url: https://crbug.com/591099
   results:
   - test: shaping-009.html
     status: FAIL

--- a/css/css-text/tab-size/META.yml
+++ b/css/css-text/tab-size/META.yml
@@ -14,6 +14,6 @@ links:
   - test: tab-size-spacing-001.html
     status: FAIL
 - product: chrome
-  url: crbug.com/921318
+  url: https://crbug.com/921318
   results:
   - test: tab-size-spacing-001.html

--- a/css/css-text/text-indent/META.yml
+++ b/css/css-text/text-indent/META.yml
@@ -28,6 +28,6 @@ links:
   - test: text-indent-percentage-004.html
     status: FAIL
 - product: chrome
-  url: crbug.com/970200
+  url: https://crbug.com/970200
   results:
   - test: text-indent-tab-positions-001.html

--- a/css/css-text/text-transform/META.yml
+++ b/css/css-text/text-transform/META.yml
@@ -93,10 +93,10 @@ links:
   - test: text-transform-shaping-003.html
     status: FAIL
 - product: chrome
-  url: crbug.com/906369
+  url: https://crbug.com/906369
   results:
   - test: text-transform-capitalize-033.html
 - product: chrome
-  url: crbug.com/1030452
+  url: https://crbug.com/1030452
   results:
   - test: text-transform-upperlower-016.html

--- a/css/css-text/white-space/META.yml
+++ b/css/css-text/white-space/META.yml
@@ -129,12 +129,12 @@ links:
   - test: trailing-other-space-separators-001.html
   - test: trailing-other-space-separators-002.html
   - test: trailing-other-space-separators-003.html
-  url: crbug.com/991413
+  url: https://crbug.com/991413
 - product: chrome
   results:
   - status: FAIL
     test: tab-stop-threshold-005.html
-  url: crbug.com/918764
+  url: https://crbug.com/918764
 - product: firefox
   results:
   - test: white-space-pre-wrap-trailing-spaces-012.html
@@ -147,26 +147,26 @@ links:
 - product: chrome
   results:
   - test: white-space-pre-wrap-trailing-spaces-003.html
-  url: crbug.com/972992
+  url: https://crbug.com/972992
 - product: chrome
   results:
   - test: pre-wrap-019.html
   - test: textarea-pre-wrap-012.html
   - test: textarea-pre-wrap-013.html
-  url: crbug.com/1008029
+  url: https://crbug.com/1008029
 - product: chrome
   results:
   - test: white-space-intrinsic-size-013.html
   - test: white-space-intrinsic-size-014.html
-  url: crbug.com/1071928
+  url: https://crbug.com/1071928
 - product: chrome
   results:
   - test: control-chars-00D.html
-  url: crbug.com/893490
+  url: https://crbug.com/893490
 - product: chrome
   results:
   - test: eol-spaces-bidi-001.html
-  url: crbug.com/1015331
+  url: https://crbug.com/1015331
 - product: firefox
   results:
   - test: seg-break-transformation-018.tentative.html

--- a/css/css-text/word-break/META.yml
+++ b/css/css-text/word-break/META.yml
@@ -135,7 +135,7 @@ links:
     test: word-break-break-all-inline-010.html
   - test: word-break-break-all-inline-007.html
   - test: word-break-break-all-inline-009.html
-  url: crbug.com/964181
+  url: https://crbug.com/964181
 - product: firefox
   results:
   - test: break-boundary-2-chars-002.html

--- a/css/css-transforms/META.yml
+++ b/css/css-transforms/META.yml
@@ -82,7 +82,7 @@ links:
         - test: transformed-preserve-3d-1.html
           status: FAIL
     - product: chrome
-      url: crbug.com/1008483
+      url: https://crbug.com/1008483
       results:
         - test: preserve-3d-flat-grouping-properties.html
           status: FAIL
@@ -91,7 +91,7 @@ links:
         - test: backface-visibility-hidden-005.tentative.html
         - test: backface-visibility-hidden-animated-002.html
     - product: chrome
-      url: crbug.com/753080
+      url: https://crbug.com/753080
       results:
         - test: transform3d-perspective-003.html
           status: FAIL
@@ -106,12 +106,12 @@ links:
         - test: transform3d-sorting-004.html
           status: FAIL
     - product: chrome
-      url: crbug.com/954591
+      url: https://crbug.com/954591
       results:
         - test: composited-under-rotateY-180deg.html
         - test: composited-under-rotateY-180deg-clip.html
     - product: chrome
-      url: crbug.com/1029997
+      url: https://crbug.com/1029997
       results:
         - test: transform-scale-percent-001.html
     - product: safari

--- a/css/css-transforms/parsing/META.yml
+++ b/css/css-transforms/parsing/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/924472
+  url: https://crbug.com/924472
   results:
   - test: transform-box-valid.html
     status: FAIL

--- a/css/css-transforms/transform-box/META.yml
+++ b/css/css-transforms/transform-box/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/924472
+  url: https://crbug.com/924472
   results:
   - test: cssbox-border-box.html
     status: FAIL

--- a/css/css-transitions/META.yml
+++ b/css/css-transitions/META.yml
@@ -16,17 +16,17 @@ links:
     subtest: CSS Transitions targetting (pseudo-)elements should have correct order
       after sorting (::marker)
 - product: chrome
-  url: crbug.com/1074547
+  url: https://crbug.com/1074547
   results:
   - test: transitioncancel-002.html
     status: TIMEOUT
 - product: chrome
-  url: crbug.com/868224
+  url: https://crbug.com/868224
   results:
   - test: idlharness.html
     status: FAIL
 - product: chrome
-  url: crbug.com/825262
+  url: https://crbug.com/825262
   results:
   - test: properties-value-inherit-001.html
     status: FAIL

--- a/css/css-typed-om/the-stylepropertymap/computed/META.yml
+++ b/css/css-typed-om/the-stylepropertymap/computed/META.yml
@@ -1,5 +1,5 @@
 links:
 - product: chrome
-  url: crbug.com/989123
+  url: https://crbug.com/989123
   results:
   - test: get-auto-min-size.html

--- a/css/css-ui/META.yml
+++ b/css/css-ui/META.yml
@@ -88,10 +88,10 @@ links:
   - test: appearance-button-001.html
   - test: webkit-appearance-button-001.html
 - product: chrome
-  url: crbug.com/591099
+  url: https://crbug.com/591099
   results:
   - test: text-overflow-015.html
 - product: chrome
-  url: crbug.com/745905
+  url: https://crbug.com/745905
   results:
   - test: text-overflow-021.html

--- a/css/css-values/META.yml
+++ b/css/css-values/META.yml
@@ -210,7 +210,7 @@ links:
   - test: ch-pseudo-recalc-on-font-load.html
     subtest: ch in pseudo-element ::first-line should be recalculated after loading a web font
 - product: chrome
-  url: crbug.com/931216
+  url: https://crbug.com/931216
   results:
   - test: calc-z-index-fractions-001.html
     status: FAIL
@@ -218,27 +218,27 @@ links:
     status: FAIL
   - test: calc-integer.html
 - product: chrome
-  url: crbug.com/1026945
+  url: https://crbug.com/1026945
   results:
   - test: minmax-length-percent-serialize.html
     status: FAIL
 - product: chrome
-  url: crbug.com/769931
+  url: https://crbug.com/769931
   results:
   - test: viewport-units-css2-001.html
     status: FAIL
 - product: chrome
-  url: crbug.com/759914
+  url: https://crbug.com/759914
   results:
   - test: ch-unit-002.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1008471
+  url: https://crbug.com/1008471
   results:
   - test: minmax-number-serialize.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1050968
+  url: https://crbug.com/1050968
   results:
   - test: calc-background-position-003.html
     subtest: 'testing background-position: calc(6px + 21%) calc(7em + 22%)'
@@ -250,6 +250,6 @@ links:
     subtest: testing calc(50px + calc(40%))
   - test: calc-serialization-002.html
 - product: chrome
-  url: crbug.com/1053965
+  url: https://crbug.com/1053965
   results:
   - test: ex-unit-004.html

--- a/css/css-will-change/META.yml
+++ b/css/css-will-change/META.yml
@@ -1,5 +1,5 @@
 links:
 - product: chrome
-  url: crbug.com/1128440
+  url: https://crbug.com/1128440
   results:
   - test: will-change-transform-zero-size-child-overflow-visible.html

--- a/css/css-writing-modes/META.yml
+++ b/css/css-writing-modes/META.yml
@@ -1115,12 +1115,12 @@ links:
   - test: vertical-alignment-srl-040.xht
     status: FAIL
 - product: chrome
-  url: crbug.com/664386
+  url: https://crbug.com/664386
   results:
   - test: inline-table-alignment-003.xht
   - test: inline-table-alignment-005.xht
 - product: chrome
-  url: crbug.com/1020373
+  url: https://crbug.com/1020373
   results:
   - test: line-box-direction-vlr-016.xht
   - test: line-box-direction-vrl-015.xht
@@ -1129,7 +1129,7 @@ links:
   - test: block-flow-direction-vlr-018.xht
   - test: block-flow-direction-vrl-017.xht
 - product: chrome
-  url: crbug.com/1005518
+  url: https://crbug.com/1005518
   results:
   - test: direction-upright-001.html
   - test: direction-upright-002.html

--- a/css/cssom-view/META.yml
+++ b/css/cssom-view/META.yml
@@ -48,7 +48,7 @@ links:
   - test: idlharness.html
     subtest: 'CSSPseudoElement interface: operation getBoxQuads(optional BoxQuadOptions)'
 - product: chrome
-  url: crbug.com/1014421
+  url: https://crbug.com/1014421
   results:
   - test: MediaQueryList-addListener-handleEvent.html
     status: TIMEOUT

--- a/css/cssom/META.yml
+++ b/css/cssom/META.yml
@@ -151,7 +151,7 @@ links:
         - test: CSSStyleSheet-modify-after-removal.html
           subtest: Modify constructed sheet from removed iframe
     - product: chrome
-      url: crbug.com/949807
+      url: https://crbug.com/949807
       results:
         - test: cssstyledeclaration-custom-properties.html
           status: FAIL

--- a/css/selectors/META.yml
+++ b/css/selectors/META.yml
@@ -54,7 +54,7 @@ links:
       results:
         - test: is-specificity-shadow.html
     - product: chrome
-      url: crbug/1156069
+      url: https://crbug.com/1156069
       results:
         - test: user-invalid.html
           subtest: :user-invalid selector should be supported

--- a/css/selectors/META.yml
+++ b/css/selectors/META.yml
@@ -59,11 +59,6 @@ links:
         - test: user-invalid.html
           subtest: :user-invalid selector should be supported
     - product: chrome
-      url: https://crbug.com/1156069
-      results:
-        - test: user-invalid.html
-          subtest: :user-invalid selector should be supported
-    - product: chrome
       url: https://crbug.com/976438
       results:
         - test: focus-visible-007.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/META.yml
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/576815
+  url: https://crbug.com/576815
   results:
   - test: dir-style-03a.html
     status: FAIL

--- a/dom/nodes/META.yml
+++ b/dom/nodes/META.yml
@@ -52,7 +52,7 @@ links:
   - test: attributes.html
     subtest: First set attribute is returned with mapped attribute set first
 - product: chrome
-  url: crbug.com/1068619
+  url: https://crbug.com/1068619
   results:
   - test: ParentNode-querySelector-escapes.html
     status: FAIL

--- a/fetch/api/policies/META.yml
+++ b/fetch/api/policies/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/651761
+  url: https://crbug.com/651761
   results:
   - test: csp-blocked-worker.html
     status: FAIL

--- a/fetch/api/redirect/META.yml
+++ b/fetch/api/redirect/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/651761
+  url: https://crbug.com/651761
   results:
   - test: redirect-location.any.html
     status: FAIL

--- a/fetch/data-urls/META.yml
+++ b/fetch/data-urls/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/807562
+  url: https://crbug.com/807562
   results:
   - test: processing.any.html
     status: FAIL

--- a/fetch/http-cache/META.yml
+++ b/fetch/http-cache/META.yml
@@ -5,12 +5,12 @@ links:
   - test: cc-request.any.html
     status: FAIL
 - product: chrome
-  url: crbug.com/74981
+  url: https://crbug.com/74981
   results:
   - test: cc-request.any.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1021668
+  url: https://crbug.com/1021668
   results:
   - test: invalidate.any.html
     status: FAIL

--- a/fetch/origin/META.yml
+++ b/fetch/origin/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/1066422
+  url: https://crbug.com/1066422
   results:
   - test: assorted.window.html
     status: FAIL

--- a/html/browsers/browsing-the-web/navigating-across-documents/META.yml
+++ b/html/browsers/browsing-the-web/navigating-across-documents/META.yml
@@ -3,7 +3,7 @@ links:
   results:
   - status: FAIL
     test: 009.html
-  url: crbug.com/651762
+  url: https://crbug.com/651762
 - product: firefox
   results:
   - subtest: COEP check precedes X-Frame-Options check

--- a/html/browsers/history/the-history-interface/META.yml
+++ b/html/browsers/history/the-history-interface/META.yml
@@ -1,6 +1,6 @@
 links:
   - product: chrome
-    url: bugs.chromium.org/p/chromium/issues/detail?id=592874
+    url: https://bugs.chromium.org/p/chromium/issues/detail?id=592874
     results:
     - test: 007.html
       status: FAIL

--- a/html/browsers/history/the-location-interface/META.yml
+++ b/html/browsers/history/the-location-interface/META.yml
@@ -15,7 +15,7 @@ links:
   - test: location-valueof.html
   - test: location-stringifier.html
 - product: chrome
-  url: crbug.com/664681
+  url: https://crbug.com/664681
   results:
   - test: location-prototype-setting-goes-cross-origin-domain.sub.html
     status: FAIL
@@ -28,7 +28,7 @@ links:
   - test: location-prototype-setting-cross-origin.sub.html
     status: FAIL
 - product: chrome
-  url: crbug.com/678633
+  url: https://crbug.com/678633
   results:
   - test: location-protocol-setter-non-broken.html
     status: FAIL

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/META.yml
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/1048149
+  url: https://crbug.com/1048149
   results:
   - test: open-features-non-integer-screeny.html
     status: FAIL

--- a/html/browsers/the-windowproxy-exotic-object/META.yml
+++ b/html/browsers/the-windowproxy-exotic-object/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/701960
+  url: https://crbug.com/701960
   results:
   - test: windowproxy-prototype-setting-goes-cross-origin-domain.sub.html
     status: FAIL

--- a/html/canvas/offscreen/text/META.yml
+++ b/html/canvas/offscreen/text/META.yml
@@ -3,7 +3,7 @@ links:
   results:
   - test: 2d.text.measure.width.space.html
   - test: 2d.text.measure.width.space.worker.html
-  url: crbug.com/1066953
+  url: https://crbug.com/1066953
 - product: webkitgtk
   results:
   - test: '*'

--- a/html/infrastructure/safe-passing-of-structured-data/META.yml
+++ b/html/infrastructure/safe-passing-of-structured-data/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/816447
+  url: https://crbug.com/816447
   results:
   - test: transfer-errors.window.html
     status: FAIL

--- a/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/META.yml
+++ b/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/META.yml
@@ -3,12 +3,12 @@ links:
   results:
   - status: FAIL
     test: fieldset-overflow.html
-  url: crbug.com/786475
+  url: https://crbug.com/786475
 - product: chrome
   results:
   - status: FAIL
     test: fieldset-multicol.html
-  url: crbug.com/875235
+  url: https://crbug.com/875235
 - product: chrome
   results:
   - subtest: fieldset multicol
@@ -17,7 +17,7 @@ links:
 - product: chrome
   results:
   - test: legend-align-text-align.html
-  url: https:/crbug.com/880822
+  url: https://crbug.com/880822
 - product: firefox
   results:
   - subtest: The rendered LEGEND should work well for :hover.

--- a/html/semantics/document-metadata/the-link-element/META.yml
+++ b/html/semantics/document-metadata/the-link-element/META.yml
@@ -5,7 +5,7 @@ links:
   - test: link-multiple-load-events.html
   - test: link-multiple-error-events.html
 - product: chrome
-  url: crbug.com/803942
+  url: https://crbug.com/803942
   results:
   - test: link-style-error-01.html
     status: FAIL

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/META.yml
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/651762
+  url: https://crbug.com/651762
   results:
   - test: activeCues.html
     status: FAIL

--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/META.yml
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/META.yml
@@ -19,7 +19,7 @@ links:
   - test: resource-selection-pointer-remove-text.html
     status: FAIL
 - product: chrome
-  url: crbug.com/592844
+  url: https://crbug.com/592844
   results:
   - test: resource-selection-invoke-insert-into-iframe.html
     status: FAIL

--- a/html/semantics/embedded-content/the-img-element/META.yml
+++ b/html/semantics/embedded-content/the-img-element/META.yml
@@ -12,12 +12,12 @@ links:
   results:
   - status: FAIL
     test: relevant-mutations.html
-  url: crbug.com/651762
+  url: https://crbug.com/651762
 - product: chrome
   results:
   - status: FAIL
     test: img.complete.html
-  url: crbug.com/1000273
+  url: https://crbug.com/1000273
 - product: firefox
   results:
   - subtest: list of available images tuple-matching logic

--- a/html/semantics/forms/form-submission-0/META.yml
+++ b/html/semantics/forms/form-submission-0/META.yml
@@ -5,7 +5,7 @@ links:
     test: form-double-submit.html
   - status: FAIL
     test: form-double-submit-3.html
-  url: crbug.com/1087077
+  url: https://crbug.com/1087077
 - product: firefox
   results:
   - subtest: 'Form newline normalization: \n in the value becomes \r\n'

--- a/html/semantics/scripting-1/the-script-element/META.yml
+++ b/html/semantics/scripting-1/the-script-element/META.yml
@@ -28,7 +28,7 @@ links:
   results:
   - status: FAIL
     test: script-charset-01.html
-  url: crbug.com/651762
+  url: https://crbug.com/651762
 - product: firefox
   results:
   - subtest: Test evaluation order of modules

--- a/html/semantics/scripting-1/the-script-element/json-module/META.yml
+++ b/html/semantics/scripting-1/the-script-element/json-module/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/967018
+  url: https://crbug.com/967018
   results:
   - test: json-module-service-worker-test.https.tentative.html
     status: FAIL

--- a/html/semantics/scripting-1/the-script-element/module/import-meta/META.yml
+++ b/html/semantics/scripting-1/the-script-element/module/import-meta/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/831313
+  url: https://crbug.com/831313
   results:
   - test: import-meta-url.html
     status: FAIL

--- a/html/semantics/selectors/pseudo-classes/META.yml
+++ b/html/semantics/selectors/pseudo-classes/META.yml
@@ -1,11 +1,11 @@
 links:
 - product: chrome
-  url: crbug.com/921880
+  url: https://crbug.com/921880
   results:
   - test: link.html
     status: FAIL
 - product: chrome
-  url: crbug.com/939143
+  url: https://crbug.com/939143
   results:
   - test: readwrite-readonly.html
     status: FAIL

--- a/mathml/presentation-markup/direction/META.yml
+++ b/mathml/presentation-markup/direction/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/6606
+  url: https://crbug.com/6606
   results:
   - test: direction-006.html
     status: FAIL

--- a/mathml/presentation-markup/mrow/META.yml
+++ b/mathml/presentation-markup/mrow/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/6606
+  url: https://crbug.com/6606
   results:
   - test: inferred-mrow-stretchy.html
     status: FAIL

--- a/mathml/presentation-markup/operators/META.yml
+++ b/mathml/presentation-markup/operators/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/6606
+  url: https://crbug.com/6606
   results:
   - test: mo-axis-height-1.html
     status: FAIL

--- a/mathml/presentation-markup/scripts/META.yml
+++ b/mathml/presentation-markup/scripts/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/1100182
+  url: https://crbug.com/1100182
   results:
   - test: subsup-parameters-1.html
     status: FAIL

--- a/mathml/presentation-markup/spaces/META.yml
+++ b/mathml/presentation-markup/spaces/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/6606
+  url: https://crbug.com/6606
   results:
   - test: space-like-001.html
     status: FAIL

--- a/mathml/presentation-markup/tables/META.yml
+++ b/mathml/presentation-markup/tables/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/6606
+  url: https://crbug.com/6606
   results:
   - test: table-001.html
     status: FAIL

--- a/mathml/relations/css-styling/META.yml
+++ b/mathml/relations/css-styling/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/6606
+  url: https://crbug.com/6606
   results:
   - test: displaystyle-011.html
     status: FAIL

--- a/mathml/relations/html5-tree/META.yml
+++ b/mathml/relations/html5-tree/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/6606
+  url: https://crbug.com/6606
   results:
   - test: href-click-1.html
     status: FAIL

--- a/media-source/META.yml
+++ b/media-source/META.yml
@@ -80,7 +80,7 @@ links:
   - test: mediasource-duration-boundaryconditions.html
     status: FAIL
 - product: chrome
-  url: crbug.com/535738
+  url: https://crbug.com/535738
   results:
   - test: mediasource-changetype-play-implicit.html
     status: FAIL
@@ -89,7 +89,7 @@ links:
   - test: mediasource-changetype-play-without-codecs-parameter.html
     status: FAIL
 - product: chrome
-  url: crbug.com/651765
+  url: https://crbug.com/651765
   results:
   - test: SourceBuffer-abort-updating.html
     status: FAIL

--- a/mixed-content/gen/top.meta/unset/META.yml
+++ b/mixed-content/gen/top.meta/unset/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/1025274
+  url: https://crbug.com/1025274
   results:
   - test: audio-tag.https.html
     status: FAIL

--- a/navigation-timing/META.yml
+++ b/navigation-timing/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/1034638
+  url: https://crbug.com/1034638
   results:
   - test: test_performance_attributes.sub.html
     status: FAIL

--- a/service-workers/cache-storage/serviceworker/META.yml
+++ b/service-workers/cache-storage/serviceworker/META.yml
@@ -1,11 +1,11 @@
 links:
 - product: chrome
-  url: crbug.com/831557
+  url: https://crbug.com/831557
   results:
   - test: cache-keys.https.html
     status: FAIL
 - product: chrome
-  url: crbug.com/432746
+  url: https://crbug.com/432746
   results:
   - test: cache-storage.https.html
     status: FAIL

--- a/service-workers/cache-storage/window/META.yml
+++ b/service-workers/cache-storage/window/META.yml
@@ -1,16 +1,16 @@
 links:
 - product: chrome
-  url: crbug.com/720918
+  url: https://crbug.com/720918
   results:
   - test: cache-matchAll.https.html
     status: FAIL
 - product: chrome
-  url: crbug.com/831557
+  url: https://crbug.com/831557
   results:
   - test: cache-keys.https.html
     status: FAIL
 - product: chrome
-  url: crbug.com/432746
+  url: https://crbug.com/432746
   results:
   - test: cache-storage.https.html
     status: FAIL

--- a/service-workers/cache-storage/worker/META.yml
+++ b/service-workers/cache-storage/worker/META.yml
@@ -1,11 +1,11 @@
 links:
 - product: chrome
-  url: crbug.com/831557
+  url: https://crbug.com/831557
   results:
   - test: cache-keys.https.html
     status: FAIL
 - product: chrome
-  url: crbug.com/720918
+  url: https://crbug.com/720918
   results:
   - test: cache-matchAll.https.html
     status: FAIL

--- a/service-workers/service-worker/META.yml
+++ b/service-workers/service-worker/META.yml
@@ -38,16 +38,6 @@ links:
         - test: fetch-canvas-tainting-video-with-range-request.https.html
           status: TIMEOUT
     - product: chrome
-      url: https://crbug.com/595993
-      results:
-        - test: fetch-header-visibility.https.html
-          status: FAIL
-    - product: chrome
-      url: https://crbug.com/824647
-      results:
-        - test: update-registration-with-type.https.html
-          status: FAIL
-    - product: chrome
       url: https://crbug.com/807720
       results:
         - test: local-url-inherit-controller.https.html
@@ -134,6 +124,8 @@ links:
     - product: chrome
       url: https://crbug.com/595993
       results:
+        - test: fetch-header-visibility.https.html
+          status: FAIL
         - test: request-end-to-end.https.html
           subtest: Test FetchEvent.request passed to onfetch
     - product: chrome
@@ -195,6 +187,8 @@ links:
         - test: import-module-scripts.https.html
         - test: registration-scope-module-static-import.https.html
         - test: registration-script-module.https.html
+        - test: update-registration-with-type.https.html
+          status: FAIL
     - product: chrome
       url: https://bugs.chromium.org/p/chromium/issues/detail?id=906991
       results:

--- a/service-workers/service-worker/META.yml
+++ b/service-workers/service-worker/META.yml
@@ -38,57 +38,57 @@ links:
         - test: fetch-canvas-tainting-video-with-range-request.https.html
           status: TIMEOUT
     - product: chrome
-      url: crbug.com/595993
+      url: https://crbug.com/595993
       results:
         - test: fetch-header-visibility.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/824647
+      url: https://crbug.com/824647
       results:
         - test: update-registration-with-type.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/807720
+      url: https://crbug.com/807720
       results:
         - test: local-url-inherit-controller.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/617886
+      url: https://crbug.com/617886
       results:
         - test: update-recovery.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/889798
+      url: https://crbug.com/889798
       results:
         - test: import-scripts-redirect.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/876223
+      url: https://crbug.com/876223
       results:
         - test: navigation-redirect.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/854058
+      url: https://crbug.com/854058
       results:
         - test: detached-context.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/751959
+      url: https://crbug.com/751959
       results:
         - test: clients-matchall-client-types.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/1014676
+      url: https://crbug.com/1014676
       results:
         - test: fetch-waits-for-activate.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/969740
+      url: https://crbug.com/969740
       results:
         - test: registration-updateviacache.https.html
           status: FAIL
     - product: chrome
-      url: crbug.com/988582
+      url: https://crbug.com/988582
       results:
         - test: unregister-then-register-new-script.https.html
           status: FAIL
@@ -154,26 +154,26 @@ links:
         - test: appcache-ordering-main.https.html
         - test: claim-fetch-with-appcache.https.html
     - product: chrome
-      url: crbug.com/805225
+      url: https://crbug.com/805225
       results:
         - test: unregister-then-register.https.html
           subtest: Unregister then register does not resolve to the original value even if the registration is in use.
         - test: unregister-then-register.https.html
           subtest: Unregister then register does not resurrect the registration
     - product: edge
-      url: crbug.com/805225
+      url: https://crbug.com/805225
       results:
         - test: unregister-then-register.https.html
           subtest: Unregister then register does not resolve to the original value even if the registration is in use.
         - test: unregister-then-register.https.html
           subtest: Unregister then register does not resurrect the registration
     - product: chrome
-      url: crbug.com/1072298
+      url: https://crbug.com/1072298
       results:
         - test: next-hop-protocol.https.html
           subtest: nextHopProtocol reports H2 correctly when routed via a service worker.
     - product: edge
-      url: crbug.com/1072298
+      url: https://crbug.com/1072298
       results:
         - test: next-hop-protocol.https.html
           subtest: nextHopProtocol reports H2 correctly when routed via a service worker.

--- a/shadow-dom/META.yml
+++ b/shadow-dom/META.yml
@@ -13,7 +13,7 @@ links:
   results:
   - status: FAIL
     test: offsetParent-across-shadow-boundaries.html
-  url: crbug.com/920069
+  url: https://crbug.com/920069
 - product: chrome
   results:
   - subtest: event.path should not exist

--- a/svg/META.yml
+++ b/svg/META.yml
@@ -334,7 +334,7 @@ links:
     subtest: 'SVGElement interface: objects.symbol must inherit property "correspondingUseElement"
       with the proper type'
 - product: chrome
-  url: crbug.com/1074549
+  url: https://crbug.com/1074549
   results:
   - test: idlharness.window.html
     status: FAIL

--- a/svg/painting/reftests/META.yml
+++ b/svg/painting/reftests/META.yml
@@ -1,6 +1,6 @@
 links:
     - product: chrome
-      url: crbug.com/1056492
+      url: https://crbug.com/1056492
       results:
         - test: marker-path-001.svg
           status: FAIL

--- a/url/META.yml
+++ b/url/META.yml
@@ -11,17 +11,17 @@ links:
   - test: a-element.html
     status: FAIL
 - product: chrome
-  url: crbug.com/943026
+  url: https://crbug.com/943026
   results:
   - test: url-constructor.any.html
     status: FAIL
 - product: chrome
-  url: crbug.com/803103
+  url: https://crbug.com/803103
   results:
   - test: a-element.html
     status: FAIL
 - product: chrome
-  url: crbug.com/819342
+  url: https://crbug.com/819342
   results:
   - test: url-setters.html
     status: FAIL

--- a/wasm/serialization/module/META.yml
+++ b/wasm/serialization/module/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/877286
+  url: https://crbug.com/877286
   results:
   - test: no-transferring.html
     status: FAIL

--- a/web-animations/interfaces/KeyframeEffect/META.yml
+++ b/web-animations/interfaces/KeyframeEffect/META.yml
@@ -10,7 +10,7 @@ links:
   - test: iterationComposite.html
     status: FAIL
 - product: chrome
-  url: crbug.com/629070
+  url: https://crbug.com/629070
   results:
   - test: constructor.html
     status: FAIL

--- a/web-animations/timing-model/timelines/META.yml
+++ b/web-animations/timing-model/timelines/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/898176
+  url: https://crbug.com/898176
   results:
   - test: timelines.html
     status: FAIL

--- a/webmessaging/with-options/META.yml
+++ b/webmessaging/with-options/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/660384
+  url: https://crbug.com/660384
   results:
   - test: broken-origin.html
     status: FAIL

--- a/webmessaging/with-ports/META.yml
+++ b/webmessaging/with-ports/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/660384
+  url: https://crbug.com/660384
   results:
   - test: 001.html
     status: FAIL

--- a/webmessaging/without-ports/META.yml
+++ b/webmessaging/without-ports/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/660384
+  url: https://crbug.com/660384
   results:
   - test: 001.html
     status: FAIL

--- a/webrtc/META.yml
+++ b/webrtc/META.yml
@@ -15,49 +15,49 @@ links:
   - test: getstats.html
     status: TIMEOUT
 - product: chrome
-  url: crbug.com/1045403
+  url: https://crbug.com/1045403
   results:
   - test: RTCConfiguration-iceServers.html
     status: FAIL
 - product: chrome
-  url: crbug.com/964184
+  url: https://crbug.com/964184
   results:
   - test: RTCPeerConnection-addIceCandidate.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1094930
+  url: https://crbug.com/1094930
   results:
   - test: receiver-track-live.https.html
     status: FAIL
 - product: chrome
-  url: crbug.com/924255
+  url: https://crbug.com/924255
   results:
   - test: RTCTrackEvent-constructor.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1050317
+  url: https://crbug.com/1050317
   results:
   - test: RTCPeerConnection-setLocalDescription-answer.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1057527
+  url: https://crbug.com/1057527
   results:
   - test: RTCPeerConnection-setLocalDescription-parameterless.https.html
     status: FAIL
   - test: RTCDTMFSender-insertDTMF.https.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1035578
+  url: https://crbug.com/1035578
   results:
   - test: RTCDTMFSender-ontonechange.https.html
     status: FAIL
 - product: chrome
-  url: crbug.com/589489
+  url: https://crbug.com/589489
   results:
   - test: RTCPeerConnection-generateCertificate.html
     status: FAIL
 - product: chrome
-  url: crbug.com/1043503
+  url: https://crbug.com/1043503
   results:
   - test: RTCRtpReceiver-getSynchronizationSources.https.html
     status: FAIL
@@ -68,7 +68,7 @@ links:
   - test: idlharness.https.window.html
     status: FAIL
 - product: chrome
-  url: crbug.com/812552
+  url: https://crbug.com/812552
   results:
   - test: RTCDataChannel-send.html
     status: FAIL

--- a/websockets/META.yml
+++ b/websockets/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/978151
+  url: https://crbug.com/978151
   results:
   - test: Create-Secure-url-with-space.any.html
     status: FAIL

--- a/websockets/constructor/META.yml
+++ b/websockets/constructor/META.yml
@@ -5,7 +5,7 @@ links:
   - test: 011.html
     status: FAIL
 - product: chrome
-  url: crbug.com/978151
+  url: https://crbug.com/978151
   results:
   - test: 002.html
     status: FAIL

--- a/xhr/META.yml
+++ b/xhr/META.yml
@@ -1,6 +1,6 @@
 links:
 - product: chrome
-  url: crbug.com/571722
+  url: https://crbug.com/571722
   results:
   - test: setrequestheader-header-allowed.htm
     subtest: "XMLHttpRequest: setRequestHeader() - headers that are allowed (User-Agent)"
@@ -10,7 +10,7 @@ links:
   - test: header-user-agent-sync.htm
     status: FAIL
 - product: chrome
-  url: crbug.com/651750
+  url: https://crbug.com/651750
   results:
   - test: responseXML-unavailable-in-worker.html
     status: FAIL
@@ -39,17 +39,17 @@ links:
   - test: responsexml-media-type.htm
     status: FAIL
 - product: chrome
-  url: crbug.com/787704
+  url: https://crbug.com/787704
   results:
   - test: send-redirect-to-cors.htm
     status: FAIL
 - product: chrome
-  url: crbug.com/699085
+  url: https://crbug.com/699085
   results:
   - test: overridemimetype-blob.html
     status: FAIL
 - product: chrome
-  url: crbug.com/588103
+  url: https://crbug.com/588103
   results:
   - test: response-json.htm
     status: FAIL


### PR DESCRIPTION
This fixes a mix of issues, mostly missing the scheme, but also some
like https:/crbug.com/880822 (missing a slash) and ' crbug.com/1008951'
(leading space) and "885175" (just a number as a string).

Related to https://github.com/web-platform-tests/wpt-metadata/issues/591.