### PR TITLE
[Checks] Remove passing Pointerevent tests

### DIFF
--- a/pointerevents/META.yml
+++ b/pointerevents/META.yml
@@ -145,8 +145,6 @@ links:
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1664335
 - product: firefox
   results:
-  - subtest: auxclick is a PointerEvent
-    test: pointerevent_auxclick_is_a_pointerevent.html
   - subtest: click is a PointerEvent
     test: pointerevent_click_is_a_pointerevent.html
   - subtest: contextmenu is a PointerEvent
@@ -168,10 +166,6 @@ links:
   results:
   - test: pointerevent_fractional_coordinates.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1680669
-- product: firefox
-  results:
-  - test: pointerevent_auxclick_is_a_pointerevent.html
-  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1685432
 - product: firefox
   results:
   - test: pointerevent_touch-action-mouse.html


### PR DESCRIPTION
This test no longer fails; see https://wpt.fyi/results/pointerevents?diff&filter=ADC&run_id=5711456496517120&run_id=4845485124747264