### PR TITLE
Remove css/css-transitions/properties-value-auto-001.html metadata

### DIFF
--- a/css/css-transitions/META.yml
+++ b/css/css-transitions/META.yml
@@ -4,11 +4,6 @@ links:
       results:
         - test: before-load-001.html
           status: TIMEOUT
-    - product: webkitgtk
-      url: https://bugs.webkit.org/show_bug.cgi?id=203416
-      results:
-        - test: properties-value-auto-001.html
-          status: FAIL
     - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1635407
       results:


### PR DESCRIPTION
The test was removed in https://github.com/web-platform-tests/wpt/pull/27923.