### PR TITLE
Delete non-URL for table-as-item-min-height-1.html

### DIFF
--- a/css/css-flexbox/META.yml
+++ b/css/css-flexbox/META.yml
@@ -579,10 +579,6 @@ links:
         - test: table-as-item-min-height-1.html
         - test: table-as-item-specified-height.html
     - product: chrome
-      url: table-as-item-min-height-1.html
-      results:
-        - test: table-as-item-min-height-1.html
-    - product: chrome
       url: https://bugs.chromium.org/p/chromium/issues/detail?id=1114306
       results:
         - test: negative-overflow.html


### PR DESCRIPTION
This reverts https://github.com/web-platform-tests/wpt-metadata/pull/1127.