### PR TITLE
Remove interop-2021 label from a houdini-dependent test

### DIFF
--- a/css/css-transforms/animation/META.yml
+++ b/css/css-transforms/animation/META.yml
@@ -19,7 +19,6 @@ links:
         - test: transform-interpolation-004.html
         - test: transform-interpolation-005.html
         - test: transform-interpolation-006.html
-        - test: transform-interpolation-computed-value.html
         - test: transform-interpolation-matrix.html
         - test: transform-interpolation-rotate-slerp.html
         - test: transform-interpolation-rotate.html


### PR DESCRIPTION
Matches https://github.com/Ecosystem-Infra/wpt-results-analysis/pull/66.