### PR TITLE
Drop modal-dialog-scroll-height.html from Interop 2022

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/META.yml
+++ b/html/semantics/interactive-elements/the-dialog-element/META.yml
@@ -80,7 +80,6 @@ links:
         - test: submit-dialog-close-event.html
         - test: synthetic-click-inert.html
         - test: top-layer-position-static.html
-        - test: modal-dialog-scroll-height.html
         - test: multiple-centered-dialogs.html
         - test: top-layer-position-relative.html
     - product: firefox


### PR DESCRIPTION
Reason:
https://github.com/web-platform-tests/interop-2022/issues/12
https://github.com/web-platform-tests/wpt/pull/32319
