### PR TITLE
Drop interop-2021-flexbox label from print reftests

### DIFF
--- a/css/css-flexbox/META.yml
+++ b/css/css-flexbox/META.yml
@@ -66,8 +66,6 @@ links:
         - test: auto-margins-003.html
         - test: box-sizing-001.html
         - test: box-sizing-min-max-sizes-001.html
-        - test: break-nested-float-in-flex-item-001-print.html
-        - test: break-nested-float-in-flex-item-002-print.html
         - test: canvas-contain-size.html
         - test: change-column-flex-width.html
         - test: column-flex-child-with-overflow-scroll.html


### PR DESCRIPTION
Matches https://github.com/Ecosystem-Infra/wpt-results-analysis/commit/f805a0eaeab7568ffc53d2df9b363ebc5b76bf68.