### PR TITLE
Remove interop-2022-cascade from tests with new at-rules

### DIFF
--- a/css/css-cascade/META.yml
+++ b/css/css-cascade/META.yml
@@ -2,15 +2,12 @@ links:
 - label: interop-2022-cascade
   results:
   - test: layer-basic.html
-  - test: layer-counter-style-override.html
   - test: layer-cssom-order-reverse.html
   - test: layer-font-face-override.html
   - test: layer-import.html
   - test: layer-keyframes-override.html
   - test: layer-media-query.html
-  - test: layer-property-override.html
   - test: layer-rules-cssom.html
-  - test: layer-scroll-timeline-override.html
   - test: layer-slotted-rule.html
   - test: layer-statement-before-import.html
   - test: layer-stylesheet-sharing-important.html
@@ -26,7 +23,6 @@ links:
   - test: revert-layer-008.html
   - test: revert-layer-009.html
   - test: revert-layer-010.html
-  - test: revert-layer-011.html
   - test: revert-layer-012.html
 - product: webkitgtk
   results:


### PR DESCRIPTION
Specifically, removes tests which use @property, @counter-style or
@scroll-timeline rules.

See https://github.com/web-platform-tests/interop-2022/issues/5#issuecomment-1015903354 for more detail.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
