### PR TITLE
Remove some modal dialog tests from interop-2022

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/META.yml
+++ b/html/semantics/interactive-elements/the-dialog-element/META.yml
@@ -53,8 +53,6 @@ links:
         - test: modal-dialog-blocks-mouse-events.html
         - test: modal-dialog-display-contents.html
         - test: modal-dialog-generated-content.html
-        - test: modal-dialog-in-replaced-renderer.html
-        - test: modal-dialog-in-table-column.html
         - test: modal-dialog-sibling.html
         - test: remove-dialog-should-unblock-document.html
         - test: removed-element-is-removed-from-top-layer.html


### PR DESCRIPTION
The behavior is not really standardized, and some folks from Blink have agreed those tests may not be quite right.

https://github.com/w3c/csswg-drafts/issues/6939#issuecomment-1016671534

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
