### PR TITLE
Add 2 tests to interop-2022-cascade

### DIFF
--- a/css/css-cascade/META.yml
+++ b/css/css-cascade/META.yml
@@ -1,6 +1,7 @@
 links:
 - label: interop-2022-cascade
   results:
+  - test: all-prop-revert-layer-noop.html
   - test: layer-basic.html
   - test: layer-cssom-order-reverse.html
   - test: layer-font-face-override.html
@@ -13,6 +14,7 @@ links:
   - test: layer-stylesheet-sharing-important.html
   - test: layer-stylesheet-sharing.html
   - test: layer-vs-inline-style.html
+  - test: presentational-hints-rollback.html
   - test: revert-layer-001.html
   - test: revert-layer-002.html
   - test: revert-layer-003.html


### PR DESCRIPTION
all-prop-revert-layer-noop.html checks `all: revert-layer`.
presentational-hints-rollback.html checks `revert-layer` with preshints.