### PR TITLE
Remove inert-svg-hittest.html from Interop 2022

### DIFF
--- a/html/semantics/interactive-elements/the-dialog-element/META.yml
+++ b/html/semantics/interactive-elements/the-dialog-element/META.yml
@@ -82,7 +82,6 @@ links:
         - test: modal-dialog-scroll-height.html
         - test: modal-dialog-in-visibility-hidden.html
         - test: dialog-focus-shadow-double-nested.html
-        - test: inert-svg-hittest.html
         - test: modal-dialog-in-replaced-renderer.html
         - test: modal-dialog-in-table-column.html
         - test: default-color.html


### PR DESCRIPTION
It actually passes on WebKit test runner: https://github.com/WebKit/WebKit/blob/5df171bce18e37178986ed7e475a0db6eef0b814/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt

So this is most likely a WebDriver bug. Given it passes in every browser, I don't see much point in bringing down the score here.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
