### PR TITLE
Remove old catch-all classification

### DIFF
--- a/webdriver/tests/permissions/META.yml
+++ b/webdriver/tests/permissions/META.yml
@@ -1,6 +1,6 @@
 links:
     - product: firefox
-      url: https://bugzilla.mozilla.org/show_bug.cgi?id=1717840
+      url: https://bugzilla.mozilla.org/show_bug.cgi?id=1524074
       results:
         - test: set.py
           subtest: test_invalid_parameters[capabilities0-parameters0]
@@ -54,7 +54,3 @@ links:
           subtest: test_set_to_state_cross_realm[capabilities0-realmSetting1-denied]
         - test: set.py
           subtest: test_set_to_state_cross_realm[capabilities0-realmSetting1-prompt]
-    - product: firefox
-      url: https://bugzilla.mozilla.org/show_bug.cgi?id=1524074
-      results:
-        - test: set.py


### PR DESCRIPTION
Follow-up from https://github.com/web-platform-tests/wpt-metadata/pull/3057 which accidentally added a duplicated item. This PR removes the old catch-all bug reference.
