### PR TITLE
Update meta data for set_permission tests based on recent changes

### DIFF
--- a/webdriver/tests/permissions/META.yml
+++ b/webdriver/tests/permissions/META.yml
@@ -15,51 +15,16 @@ links:
     test: set.py
   - subtest: test_invalid_parameters[capabilities0-parameters6]
     test: set.py
-  - subtest: test_invalid_parameters[capabilities0-parameters7]
-    test: set.py
   - subtest: test_non_secure_context[granted]
     test: set.py
   - subtest: test_non_secure_context[denied]
     test: set.py
   - subtest: test_non_secure_context[prompt]
     test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting0-granted]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting0-denied]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting0-prompt]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting1-granted]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting1-denied]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting1-prompt]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting2-granted]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting2-denied]
-    test: set.py
-  - subtest: test_set_to_state[capabilities0-realmSetting2-prompt]
-    test: set.py
-  - subtest: test_set_to_state_cross_realm[capabilities0-realmSetting0-granted]
-    test: set.py
-  - subtest: test_set_to_state_cross_realm[capabilities0-realmSetting0-denied]
-    test: set.py
-  - subtest: test_set_to_state_cross_realm[capabilities0-realmSetting0-prompt]
-    test: set.py
-  - subtest: test_set_to_state_cross_realm[capabilities0-realmSetting1-granted]
-    test: set.py
-  - subtest: test_set_to_state_cross_realm[capabilities0-realmSetting1-denied]
-    test: set.py
-  - subtest: test_set_to_state_cross_realm[capabilities0-realmSetting1-prompt]
-    test: set.py
-  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1524074
-- product: firefox
-  results:
   - subtest: test_set_to_state[capabilities0-granted]
     test: set.py
   - subtest: test_set_to_state[capabilities0-denied]
     test: set.py
   - subtest: test_set_to_state[capabilities0-prompt]
     test: set.py
-  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1804471
+  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1524074


### PR DESCRIPTION
PR https://github.com/web-platform-tests/wpt/pull/37152 has made changes to this file and added / removed some tests. 

Any failure is still covered by bug 1524074.