### PR TITLE
Remove metadata labels from excluded tests

### DIFF
--- a/custom-elements/reactions/META.yml
+++ b/custom-elements/reactions/META.yml
@@ -211,7 +211,6 @@ links:
     - label: interop-2023-webcomponents
       results:
         - test: Animation.html
-        - test: AriaMixin-element-attributes.html
         - test: AriaMixin-string-attributes.html
         - test: Document.html
         - test: HTMLElement.html

--- a/shadow-dom/META.yml
+++ b/shadow-dom/META.yml
@@ -87,6 +87,4 @@ links:
         - test: historical.html
     - label: interop-2023-webcomponents
       results:
-        - test: DocumentOrShadowRoot-prototype-elementFromPoint.html
-        - test: MouseEvent-prototype-offsetX-offsetY.html
         - test: capturing-and-bubbling-event-listeners-across-shadow-trees.html


### PR DESCRIPTION
See
https://github.com/web-platform-tests/interop/issues/203#issuecomment-1297840962 
https://github.com/web-platform-tests/interop/issues/230#issuecomment-1293285156

Since the concerns in those issues were not addressed and there was agreement to drop the tests in that case, I'm removing them from the Interop set.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
