### PR TITLE
Remove prefer-reduced-data test from Interop 2023

### DIFF
--- a/css/mediaqueries/META.yml
+++ b/css/mediaqueries/META.yml
@@ -931,7 +931,6 @@ links:
         - test: mq-invalid-media-type-002.html
         - test: mq-invalid-media-type-layer-001.html
         - test: mq-gamut-003.html
-        - test: prefers-reduced-data.html
         - test: aspect-ratio-002.html
         - test: device-aspect-ratio-006.html
         - test: mq-invalid-media-type-005.html


### PR DESCRIPTION
It is part of media queries level 5, so it does not make sense to include in the media queries level 4 focus area.

https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-data

Fixes https://github.com/web-platform-tests/interop/issues/280

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
