### PR TITLE
Revert "Automatically Triage New Metadata"

### DIFF
--- a/service-workers/cache-storage/META.yml
+++ b/service-workers/cache-storage/META.yml
@@ -3,8 +3,3 @@ links:
       url: https://crbug.com/847357
       results:
         - test: cache-keys-attributes-for-service-worker.https.html
-    - product: safari
-      url: https://bugs.webkit.org/show_bug.cgi?id=217462
-      results:
-        - test: cache-add.https.any.serviceworker.html
-          subtest: Cache.addAll should succeed when entries differ by vary header


### PR DESCRIPTION
Reverts web-platform-tests/wpt-metadata#3969

This was the wrong bug (wrong subtest).