### PR TITLE
Update meta data for Firefox

### DIFF
--- a/webdriver/tests/find_elements_from_shadow_root/META.yml
+++ b/webdriver/tests/find_elements_from_shadow_root/META.yml
@@ -1,106 +1,15 @@
 links:
 - product: firefox
-  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1700095
   results:
-  - subtest: test_null_parameter_value
+  - subtest: test_find_elements[open-tag name-a]
     test: find.py
-  - subtest: test_no_top_browsing_context
+  - subtest: test_find_elements[closed-tag name-a]
     test: find.py
-  - subtest: test_invalid_using_argument[a]
+  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1822321
+- product: firefox
+  results:
+  - subtest: test_find_elements[open-xpath-//a]
     test: find.py
-  - subtest: test_invalid_using_argument[True]
+  - subtest: test_find_elements[closed-xpath-//a]
     test: find.py
-  - subtest: test_invalid_using_argument[None]
-    test: find.py
-  - subtest: test_invalid_using_argument[1]
-    test: find.py
-  - subtest: test_invalid_using_argument[using4]
-    test: find.py
-  - subtest: test_invalid_using_argument[using5]
-    test: find.py
-  - subtest: test_invalid_selector_argument[None]
-    test: find.py
-  - subtest: test_invalid_selector_argument[value1]
-    test: find.py
-  - subtest: test_invalid_selector_argument[value2]
-    test: find.py
-  - subtest: test_detached_shadow_root[top_context]
-    test: find.py
-  - subtest: test_detached_shadow_root[child_context]
-    test: find.py
-  - subtest: test_find_elements_equivalence
-    test: find.py
-  - subtest: test_find_elements[css selector-#linkText]
-    test: find.py
-  - subtest: test_find_elements[link text-full link text]
-    test: find.py
-  - subtest: test_find_elements[partial link text-link text]
-    test: find.py
-  - subtest: test_find_elements_link_text[<a href=#>link text</a>-link text]
-    test: find.py
-  - subtest: test_find_elements_link_text[<a href=#>&nbsp;link text&nbsp;</a>-link
-      text]
-    test: find.py
-  - subtest: test_find_elements_link_text[<a href=#>link<br>text</a>-link\ntext]
-    test: find.py
-  - subtest: test_find_elements_link_text[<a href=#>link&amp;text</a>-link&text]
-    test: find.py
-  - subtest: test_find_elements_link_text[<a href=#>LINK TEXT</a>-LINK TEXT]
-    test: find.py
-  - subtest: 'test_find_elements_link_text[<a href=# style=''text-transform: uppercase''>link
-      text</a>-LINK TEXT]'
-    test: find.py
-  - subtest: test_find_elements_partial_link_text[<a href=#>partial link text</a>-link]
-    test: find.py
-  - subtest: test_find_elements_partial_link_text[<a href=#>&nbsp;partial link text&nbsp;</a>-link]
-    test: find.py
-  - subtest: test_find_elements_partial_link_text[<a href=#>partial link text</a>-k
-      t]
-    test: find.py
-  - subtest: test_find_elements_partial_link_text[<a href=#>partial link<br>text</a>-k\nt]
-    test: find.py
-  - subtest: test_find_elements_partial_link_text[<a href=#>partial link&amp;text</a>-k&t]
-    test: find.py
-  - subtest: test_find_elements_partial_link_text[<a href=#>PARTIAL LINK TEXT</a>-LINK]
-    test: find.py
-  - subtest: 'test_find_elements_partial_link_text[<a href=# style=''text-transform:
-      uppercase''>partial link text</a>-LINK]'
-    test: find.py
-  - subtest: test_no_element[css selector-#wontExist]
-    test: find.py
-  - subtest: test_accept[capabilities0-alert-None]
-    test: user_prompts.py
-  - subtest: test_accept[capabilities0-confirm-True]
-    test: user_prompts.py
-  - subtest: test_accept[capabilities0-prompt-]
-    test: user_prompts.py
-  - subtest: test_accept_and_notify[capabilities0-alert-None]
-    test: user_prompts.py
-  - subtest: test_accept_and_notify[capabilities0-confirm-True]
-    test: user_prompts.py
-  - subtest: test_accept_and_notify[capabilities0-prompt-]
-    test: user_prompts.py
-  - subtest: test_dismiss[capabilities0-alert-None]
-    test: user_prompts.py
-  - subtest: test_dismiss[capabilities0-confirm-False]
-    test: user_prompts.py
-  - subtest: test_dismiss[capabilities0-prompt-None]
-    test: user_prompts.py
-  - subtest: test_dismiss_and_notify[capabilities0-alert-None]
-    test: user_prompts.py
-  - subtest: test_dismiss_and_notify[capabilities0-confirm-False]
-    test: user_prompts.py
-  - subtest: test_dismiss_and_notify[capabilities0-prompt-None]
-    test: user_prompts.py
-  - subtest: test_ignore[capabilities0-alert]
-    test: user_prompts.py
-  - subtest: test_ignore[capabilities0-confirm]
-    test: user_prompts.py
-  - subtest: test_ignore[capabilities0-prompt]
-    test: user_prompts.py
-  - subtest: test_default[alert-None]
-    test: user_prompts.py
-  - subtest: test_default[confirm-False]
-    test: user_prompts.py
-  - subtest: test_default[prompt-None]
-    test: user_prompts.py
+  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1822311


### PR DESCRIPTION
Support for `Find Elements in ShadowRoot` is now available in Firefox Nightly.
