### PR TITLE
Update Firefox meta data

### DIFF
--- a/webdriver/tests/get_element_property/META.yml
+++ b/webdriver/tests/get_element_property/META.yml
@@ -1,29 +1,5 @@
 links:
 - product: firefox
-  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1793845
-  results:
-  - subtest: test_primitives["foobar"-foobar]
-    test: get.py
-  - subtest: test_primitives[42-42]
-    test: get.py
-  - subtest: test_primitives[js_primitive2-py_primitive2]
-    test: get.py
-  - subtest: test_primitives[js_primitive3-py_primitive3]
-    test: get.py
-  - subtest: test_primitives_set_by_execute_script["foobar"-foobar]
-    test: get.py
-  - subtest: test_primitives_set_by_execute_script[42-42]
-    test: get.py
-  - subtest: test_primitives_set_by_execute_script[js_primitive2-py_primitive2]
-    test: get.py
-  - subtest: test_primitives_set_by_execute_script[js_primitive3-py_primitive3]
-    test: get.py
-- product: firefox
-  url: https://bugzilla.mozilla.org/show_bug.cgi?id=1764594
-  results:
-  - subtest: test_web_reference[shadowRoot-ShadowRoot]
-    test: get.py
-- product: firefox
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1274251
   results:
   - subtest: test_web_reference[frame-Frame]


### PR DESCRIPTION
Primitives and ShadowRoot are properly working now.
