### PR TITLE
Remove CQ tests that depend on TypedOM from Interop 2023

### DIFF
--- a/css/css-contain/container-queries/META.yml
+++ b/css/css-contain/container-queries/META.yml
@@ -688,7 +688,6 @@ links:
         - test: font-relative-units.html
         - test: container-units-in-at-container-dynamic.html
         - test: grid-container.html
-        - test: inner-first-line-non-matching.html
         - test: container-size-invalidation-after-load.html
         - test: container-type-invalidation.html
         - test: container-computed.html

--- a/css/css-contain/container-queries/META.yml
+++ b/css/css-contain/container-queries/META.yml
@@ -718,7 +718,6 @@ links:
         - test: chrome-legacy-skip-recalc.html
         - test: calc-evaluation.html
         - test: container-for-cue.html
-        - test: container-units-typed-om.html
         - test: fieldset-legend-change.html
         - test: font-relative-calc-dynamic.html
         - test: font-relative-units-dynamic.html
@@ -748,7 +747,6 @@ links:
         - test: top-layer-dialog-backdrop.html
         - test: table-inside-container-changing-display.html
         - test: container-inside-multicol-with-table.html
-        - test: container-units-computational-independence.html
         - test: sibling-layout-dependency.html
         - test: transition-style-change-event-002.html
         - test: container-name-parsing.html


### PR DESCRIPTION
See https://github.com/web-platform-tests/interop/issues/305
