### PR TITLE
Use fork method to have auto starting manifest PRs

### DIFF
--- a/.github/workflows/update_wpt_manifest.yml
+++ b/.github/workflows/update_wpt_manifest.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 13 * * *'
   workflow_dispatch:
 jobs:
-  update-wpt-manifes:
+  update-wpt-manifest:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -20,9 +20,9 @@ jobs:
       run: ./main
 
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.WPTMETADATA_BOT_USER_PAT }}
         author: wpt-pr-bot <wpt-pr-bot@users.noreply.github.com>
         title: "Update latest WPT Manifest for go_test"
         commit-message: "Run curl -s -S https://wpt.fyi/api/manifest?sha=latest >> go_test/MANIFEST.json"
@@ -30,3 +30,4 @@ jobs:
           This automated pull request updates the MANIFEST.json file to the latest WPT manifest daily. GitHub checks run against this manifest. If checks fail in this PR, the failing metadata should be either renamed or deleted according to the WPT repository.
         branch: actions/wpt-manifest
         delete-branch: true
+        push-to-fork: wptmetadata-bot/wpt-metadata


### PR DESCRIPTION
Using the mentioned method here: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork

Why did we create a new bot instead of using wptfyibot?
- It currently has write access to the repo. And generating a PAT for it is a security risk in case the third party peter-evans/create-pull-request action is compromised. It could then would have write access to this repository.
  - A future optimization: Once finer grain PATs are out of beta and someone tests it with peter-evans/create-pull-request, we might can consolidate back to using only wptfyibot. More about finer grain PATs can be found [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-fine-grained-personal-access-token)

In a future commit, we will update resolve_merge_conflict.yml to use the v5 of the same action

Fixes: #1444

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
