### PR TITLE
Move auto-approve job to trigger after Run Tests run

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,10 +1,17 @@
 name: Auto approve
-on: pull_request
+on:
+  workflow_run:
+    workflows: ["test"]
+    types:
+      - completed
 
 jobs:
   build:
     runs-on: ubuntu-20.04
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
     steps:
-    - uses: hmarr/auto-approve-action@v2.0.0
-      with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+    - uses: hmarr/auto-approve-action@v3


### PR DESCRIPTION
Moving to the least privileged model for creating the PR in #4090 brought a new problem: The forked PR is unable to be auto approved.

This is because PR runs do not have access to GITHUB_TOKEN which is needed for the auto approver. GitHub tightened up their security model a few years ago to prevent this. Details in this
[doc](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Also, in the doc shows the recommended implementation which this commit uses:

- Use the required "Run Tests" workflow as the unprivileged run that runs when the PR is made.
- Move the auto-approval to be triggered after the "Run Tests" workflow. This is privileged and has access to the GITHUB_TOKEN

Examples using this same way:
- https://github.com/MaibornWolff/codecharta/blob/main/.github/workflows/auto-approve-and-merge.yml

Other changes:
- Migrate to use hmarr/auto-approve-action@v3. Remove the explicit need for GITHUB_TOKEN in v3.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
