### PR TITLE
Do not auto-merge interop label

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,7 @@ jobs:
         # https://github.com/pascalgn/automerge-action#configuration
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "!do not merge yet"
+          MERGE_LABELS: "!do not merge yet,!interop"
           MERGE_FORKS: false
           MERGE_METHOD: "rebase"
           MERGE_RETRIES: "3"


### PR DESCRIPTION
Fix https://github.com/web-platform-tests/wpt-metadata/issues/3954, along with https://github.com/web-platform-tests/wpt.fyi/pull/3275. Disable auto-merge on PRs with the interop label