### PR TITLE
Fix auto-approve from workflow run

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,3 +15,5 @@ jobs:
       pull-requests: write
     steps:
     - uses: hmarr/auto-approve-action@v3
+      with:
+        pull-request-number: ${{ github.event.workflow_run.event.pull_request.number }}


### PR DESCRIPTION
Turns out that it does not know how to infer the pull request number now that it uses the workflow_run trigger.

More on the event payload
https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=opened#pull_request

