### PR TITLE
Fix the new wptmetadata-bot for manifest updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 
 1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
-2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
+2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -6,20 +6,50 @@ on:
       - completed
 
 jobs:
-  build:
+  approve:
+    name: "Approve PR"
     runs-on: ubuntu-20.04
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     permissions:
       pull-requests: write
-    strategy:
-      matrix:
-        # workflow_run contains list of pull requests
-        # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=completed#workflow_run
-        # Extract the list of successful pull requests and run approvals on them.
-        pull_request: ${{ fromJson(toJson(github.event.workflow_run.pull_requests.*.number)) }}
     steps:
+    # Currently there is no way to get the pull request number from the event payload in a workflow_run event.
+    # We save it in the test workflow
+    # These first steps extract it.
+    # More information about it:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    - name: 'Download PR number'
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          console.log("Starting to list artifacts");
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+          });
+          console.log("Filtering artifacts");
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "pr_number"
+          })[0];
+          console.log("Downloading artifacts");
+          var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+          });
+          console.log("Writing artifacts to disk");
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+    - run: unzip pr.zip
+    - name: Get the PR value and set it in the environment
+      run: |
+        echo "PR_NUMBER=$(<pr_number.txt)" >> "$GITHUB_ENV"
+        echo "Set PR_NUMBER to $PR_NUMBER"
     - uses: hmarr/auto-approve-action@v3
       with:
-        pull-request-number: ${{ matrix.pull_request }}
+        pull-request-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,19 @@ jobs:
     - uses: actions/checkout@v2
     - run: go get -v -t -d ./...
     - run: go test ./...
+  upload:
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    name: "Save PR number for Auto Approve workflow_run"
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/update_wpt_manifest.yml
+++ b/.github/workflows/update_wpt_manifest.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 jobs:
   update-wpt-manifest:
+    outputs:
+      prURL: ${{ steps.cpr.outputs.pull-request-url }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -20,6 +22,7 @@ jobs:
       run: ./main
 
     - name: Create pull request
+      id: cpr
       uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ secrets.WPTMETADATA_BOT_USER_PAT }}
@@ -30,3 +33,21 @@ jobs:
         branch: actions/wpt-manifest
         delete-branch: true
         push-to-fork: wptmetadata-bot/wpt-metadata
+  # Create a separate job for only the steps that need write permissions.
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    needs: update-wpt-manifest
+    # Need both permissions to enable auto merge.
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+    # Could use https://github.com/peter-evans/enable-pull-request-automerge but it recommends using the CLI now
+    # More about the CLI options. We need --auto so that the PR will automatically merge after:
+    # - One review
+    # - The test action is successful.
+    # https://cli.github.com/manual/gh_pr_merge
+    - name: Enable Pull Request Automerge
+      run: gh pr merge --merge --auto "${{ needs.update-wpt-manifest.outputs.prURL }}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Problem 1: New autoapprove job cannot infer the PR that started it

The new bot ran into some problems upon initial rollout. It is meant to use the principle of least privilege. This helpful for non-verified actions. More about it here: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork

During the rollout, it was discovered that the new workflow_run actually does not have access to which pull request it came from. (There will initial attempts to read from the event payload but it failed).

GitHub itself documents how to get the PR information to the subsequent workflows:
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

This commit implements that solutions.
Implementation based on what GitHub suggested:
- Save the PR number in test.yml
- use the PR number in auto-approve.yml

# Problem 2: automerge workflow does not work with forked contributions

Forks do not have access to repository secrets during the following events (which the automerge workflow uses):
- pull_request
- pull_request_review

As a result, the automerge workflow will not work on this. We get around this by now using the now built in GitHub auto merge feature. By enabling it, it does not enable auto merge for PRs. Instead, it presents the option that developers to enable automerge. If enabled, PRs will auto merge once the branch protection rules are fulfilled.

Implementation:
- Modified the update_wpt_manifest with a separate job which will enable auto merge once it is created.
- Added a note to the pull request template about human developers not using the automerge feature.

---

Requirements after this is merged:
- Enable the option for contributors to enable auto-merge
  - Human developers should not use it and there has been a note added to the PR template.
- Recreate the fork for wptmetadata-bot
- Keep the branch requirement that a reviewer must approve and that the "test" action must pass

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
