### PR TITLE
Change autoapprove to use workflow_dispatch

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -13,14 +13,20 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     permissions:
+      # Needed by gh workflow run
+      actions: write
+      # Needed by hmarr/auto-approve-action@v3
       pull-requests: write
     steps:
     # Currently there is no way to get the pull request number from the event payload in a workflow_run event.
-    # We save it in the test workflow
-    # These first steps extract it.
+    # We save it in the 'test' workflow.
+    # This first step extracts it.
     # More information about it:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    # Current limitation:
+    # As of 2023-05-18, https://github.com/actions/download-artifact cannot download artifacts across workflows.
+    # As a result, have to use the script GitHub provides to download the artifact.
     - name: 'Download PR number'
       uses: actions/github-script@v3.1.0
       with:
@@ -53,3 +59,6 @@ jobs:
     - uses: hmarr/auto-approve-action@v3
       with:
         pull-request-number: ${{ env.PR_NUMBER }}
+    - run: gh workflow run "automerge" -f prNumber=${{ env.PR_NUMBER }} --repo ${GITHUB_REPOSITORY}
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -62,4 +62,3 @@ jobs:
     - run: gh workflow run "automerge" -f prNumber=${{ env.PR_NUMBER }} --repo ${GITHUB_REPOSITORY}
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -62,3 +62,4 @@ jobs:
     - run: gh workflow run "automerge" -f prNumber=${{ env.PR_NUMBER }} --repo ${GITHUB_REPOSITORY}
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,28 +1,23 @@
 name: automerge
 on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-  pull_request_review:
-    types:
-      - submitted
-  check_suite:
-    types:
-      - completed
-  status: {}
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: 'PR Number to auto merge'
+        type: number
+        required: true
 jobs:
   automerge:
     runs-on: ubuntu-20.04
+    permissions:
+      # Need to read check suites.
+      checks: read
+      # Need to merge the pull request
+      # Specifically "PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge"
+      contents: write
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
+        uses: "pascalgn/automerge-action@v0.15.6"
         # https://github.com/pascalgn/automerge-action#configuration
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -31,3 +26,4 @@ jobs:
           MERGE_METHOD: "rebase"
           MERGE_RETRIES: "3"
           MERGE_RETRY_SLEEP: "90000"
+          PULL_REQUEST: ${{ inputs.prNumber }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     needs: [test]
     runs-on: ubuntu-latest
+    # The PR number is uploaded instead of triggering another workflow directly
+    # because this workflow has no permissions and runs with the least
+    # privileges (This pipeline can be ran by PRs made from forks).
     name: "Save PR number for Auto Approve workflow_run"
     steps:
       - name: Save PR number


### PR DESCRIPTION
Upgrade to pascalgn/automerge-action to v0.15.6
- Why:
  - Comparison of changes [shows](https://github.com/pascalgn/automerge-action/compare/135f0bdb927d9807b5446f7ca9ecc2c51de03c4a...v0.15.6#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R212) (check changes in README.md) that in the latest version of the action you can set the PULL_REQUEST
  - Also, we are leveraging "workflow_dispatch" so we need the latest version because it [supports the event](https://github.com/pascalgn/automerge-action/compare/135f0bdb927d9807b5446f7ca9ecc2c51de03c4a...v0.15.6#diff-3814d8caba69e5fdf3b23eed56ec7d708b8ede5aed6d686ac579421877938ec7R107) (check changes in lib/api.js)

Switch automerge yml to listen for workflow_dispatch.
- Now what happens:
  - Test Workflow -> Auto approve -> Auto merge

Other changes:
- Other clarifications on permissions

[More](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28) about the permissions specified for each workflow

Evidence of it working:
- [Auto merging a a successful test](https://github.com/jcscottiii/wpt-metadata/pull/25)
- [Blocking on interop label](https://github.com/jcscottiii/wpt-metadata/pull/27)
- [Blocking on do not merge label](https://github.com/jcscottiii/wpt-metadata/pull/26)

Addresses #4199 