### PR TITLE
Remove obsolete Safari bug links for WebCodecs

### DIFF
--- a/webcodecs/META.yml
+++ b/webcodecs/META.yml
@@ -1,21 +1,4 @@
 links:
-    - product: safari
-      url: https://bugs.webkit.org/show_bug.cgi?id=183720
-      results:
-        - test: reconfiguring-encoder.https.any.html?h264_annexb
-        - test: temporal-svc-encoding.https.any.worker.html?h264
-        - test: reconfiguring-encoder.https.any.worker.html?vp8
-        - test: temporal-svc-encoding.https.any.html?h264
-        - test: reconfiguring-encoder.https.any.html?vp9_p0
-        - test: reconfiguring-encoder.https.any.html?h264_avc
-        - test: reconfiguring-encoder.https.any.html?vp8
-        - test: temporal-svc-encoding.https.any.worker.html?vp8
-        - test: temporal-svc-encoding.https.any.html?vp9
-        - test: temporal-svc-encoding.https.any.worker.html?vp9
-        - test: reconfiguring-encoder.https.any.worker.html?vp9_p0
-        - test: reconfiguring-encoder.https.any.worker.html?h264_annexb
-        - test: temporal-svc-encoding.https.any.html?vp8
-        - test: reconfiguring-encoder.https.any.worker.html?h264_avc
     - label: interop-2023-webcodecs
       results:
         - test: video-encoder.https.any.worker.html


### PR DESCRIPTION
OffscreenCanvas has shipped in Safari.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
