### PR TITLE
Remove 2d.text.measure.advances tests from interop-2023

### DIFF
--- a/html/canvas/offscreen/text/META.yml
+++ b/html/canvas/offscreen/text/META.yml
@@ -194,8 +194,6 @@ links:
         - test: 2d.text.font.relative_size.worker.html
         - test: 2d.text.measure.actualBoundingBox.html
         - test: 2d.text.measure.actualBoundingBox.worker.html
-        - test: 2d.text.measure.advances.html
-        - test: 2d.text.measure.advances.worker.html
         - test: 2d.text.measure.baselines.html
         - test: 2d.text.measure.baselines.worker.html
         - test: 2d.text.measure.emHeights.html


### PR DESCRIPTION
The advances attribute of TextMetrics is not present in the spec. As proposed in https://github.com/web-platform-tests/interop/issues/365 we should remove these tests from the interop-2023-offscreencanvas list.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
