### PR TITLE
add general accessibility labels to existing accessibility-related automated tests

### DIFF
--- a/accessibility/META.yml
+++ b/accessibility/META.yml
@@ -5,6 +5,3 @@ links:
     - label: accessibility
       results:
         - test: "*"
-    - label: graphics-aam
-      results:
-        - test: "*"

--- a/accessibility/crashtests/META.yml
+++ b/accessibility/crashtests/META.yml
@@ -6,6 +6,3 @@ links:
         - test: computed-accessible-child-of-pseudo-element.html
         - test: aom-in-destroyed-iframe.html
         - test: computed-node-checked.html
-    - label: a11y
-      results:
-        - test: activedescendant-crash.html

--- a/accname/META.yml
+++ b/accname/META.yml
@@ -5,6 +5,6 @@ links:
     - label: accessibility
       results:
         - test: "*"
-    - label: graphics-aam
+    - label: accname
       results:
         - test: "*"

--- a/html-aam/META.yml
+++ b/html-aam/META.yml
@@ -1,5 +1,4 @@
 links:
-links:
     - label: a11y
       results:
         - test: "*"

--- a/html-aam/META.yml
+++ b/html-aam/META.yml
@@ -1,4 +1,14 @@
 links:
+links:
+    - label: a11y
+      results:
+        - test: "*"
+    - label: accessibility
+      results:
+        - test: "*"
+    - label: html-aam
+      results:
+        - test: "*"
     - product: chrome
       url: https://github.com/w3c/html-aam/issues/474
       results:

--- a/html/dom/META.yml
+++ b/html/dom/META.yml
@@ -2054,6 +2054,15 @@ links:
     - label: interop-2022-forms
       results:
         - test: reflection-forms.html
+    - label: a11y
+      results:
+        - test: aria-element-reflection.html
+    - label: accessibility
+      results:
+        - test: aria-element-reflection.html
+    - label: aria
+      results:
+        - test: aria-element-reflection.html
     - product: chrome
       url: https://crbug.com/1281880
       results:

--- a/inert/META.yml
+++ b/inert/META.yml
@@ -1,4 +1,13 @@
 links:
+    - label: a11y
+      results:
+        - test: "*"
+    - label: accessibility
+      results:
+        - test: "*"
+    - label: inert
+      results:
+        - test: "*"
     - product: safari
       url: https://bugs.webkit.org/show_bug.cgi?id=239017
       results:

--- a/wai-aria/META.yml
+++ b/wai-aria/META.yml
@@ -1,4 +1,13 @@
 links:
+    - label: a11y
+      results:
+        - test: "*"
+    - label: accessibility
+      results:
+        - test: "*"
+    - label: aria
+      results:
+        - test: "*"
     - product: safari
       url: https://bugs.webkit.org/show_bug.cgi?id=257141
       results:


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/43