### PR TITLE
Update tests related to bug 1831583 bug 1841363 of Firefox

### DIFF
--- a/workers/modules/META.yml
+++ b/workers/modules/META.yml
@@ -28,11 +28,6 @@ links:
       results:
         - test: shared-worker-parse-error-failure.html
     - product: firefox
-      url: https://bugzilla.mozilla.org/show_bug.cgi?id=1831583
-      results:
-        - test: shared-worker-import-data-url-cross-origin.html
-        - test: dedicated-worker-import-data-url-cross-origin.html
-    - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1841363
       results:
         - test: dedicated-worker-import-csp.html

--- a/workers/modules/META.yml
+++ b/workers/modules/META.yml
@@ -31,4 +31,9 @@ links:
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1841363
       results:
         - test: dedicated-worker-import-csp.html
+        - test: dedicated-worker-import-data-url-cross-origin.html
+        - test: dedicated-worker-import-data-url.any.html
+        - test: dedicated-worker-import-data-url.any.worker.html
         - test: shared-worker-import-csp.html
+        - test: shared-worker-import-data-url-cross-origin.html
+        - test: shared-worker-import-data-url.window.html


### PR DESCRIPTION
Remove test related to Firefox's bug 1831583. 
Add failed tests related to Firefox's bug 1841363.