### PR TITLE
Remove pointerevent_attributes_nohover_pointers.html from Interop 2023

### DIFF
--- a/pointerevents/META.yml
+++ b/pointerevents/META.yml
@@ -203,7 +203,6 @@ links:
         - test: pointerevent_hit_test_scroll_visible_descendant.html
         - test: pointerevent_pointercapture_in_frame.html?mouse
         - test: pointerup_after_pointerdown_target_removed.html?mouse
-        - test: pointerevent_attributes_nohover_pointers.html
         - test: pointerevent_movementxy.html?mouse
     - product: safari
       url: https://bugs.webkit.org/show_bug.cgi?id=218665


### PR DESCRIPTION
It is a touch input test.
Fixes https://github.com/web-platform-tests/interop/issues/574

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
