### PR TITLE
add labels for other aria reflection tests

### DIFF
--- a/html/dom/META.yml
+++ b/html/dom/META.yml
@@ -2056,13 +2056,19 @@ links:
         - test: reflection-forms.html
     - label: a11y
       results:
+        - test: aria-attribute-reflection.html
         - test: aria-element-reflection.html
+        - test: aria-element-reflection-disconnected.html
     - label: accessibility
       results:
+        - test: aria-attribute-reflection.html
         - test: aria-element-reflection.html
+        - test: aria-element-reflection-disconnected.html
     - label: aria
       results:
+        - test: aria-attribute-reflection.html
         - test: aria-element-reflection.html
+        - test: aria-element-reflection-disconnected.html
     - product: chrome
       url: https://crbug.com/1281880
       results:


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop-2023-accessibility-testing/issues/67