### PR TITLE
Clear bugs for highlight tests passing on Chrome

### DIFF
--- a/css/css-highlight-api/META.yml
+++ b/css/css-highlight-api/META.yml
@@ -87,20 +87,6 @@ links:
   - subtest: HighlightRegistry initializes as it should.
     test: HighlightRegistry-maplike.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1718818
-- product: chrome
-  results:
-  - subtest: 'Highlight interface: setlike<AbstractRange>'
-    test: idlharness.window.html
-  - subtest: 'HighlightRegistry interface: maplike<DOMString, Highlight>'
-    test: idlharness.window.html
-  url: https://crbug.com/1344001
-- product: edge
-  results:
-  - subtest: 'Highlight interface: setlike<AbstractRange>'
-    test: idlharness.window.html
-  - subtest: 'HighlightRegistry interface: maplike<DOMString, Highlight>'
-    test: idlharness.window.html
-  url: https://crbug.com/1344001
 - product: firefox
   results:
   - subtest: Highlight is a setlike interface that works as expected even if Set.prototype

--- a/css/css-highlight-api/painting/META.yml
+++ b/css/css-highlight-api/painting/META.yml
@@ -7,10 +7,6 @@ links:
   results:
   - test: custom-highlight-painting-iframe-006.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1727394
-- product: chrome
-  results:
-  - test: css-highlight-painting-underline-offset-001.html
-  url: https://crbug.com/1443428
 - product: firefox
   results:
   - test: css-highlight-painting-underline-offset-001.html


### PR DESCRIPTION
There are passing tests on Chrome in css/css-highlight-api, so remove references to the bug numbers.