### PR TITLE
webrtc: clean up stale bug entry

### DIFF
--- a/webrtc/protocol/META.yml
+++ b/webrtc/protocol/META.yml
@@ -48,10 +48,6 @@ links:
       results:
         - test: simulcast-answer.html
           subtest: createOffer() with multiple send encodings should create simulcast offer
-    - product: chrome
-      url: https://crbug.com/1127309
-      results:
-        - test: crypto-suite.https.html
     - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1307996
       results:


### PR DESCRIPTION
after the only failing test was also removed in
  https://chromiumdash.appspot.com/commit/22122fb6f485dbd5e4e8fe98a88f1c86a234e0e5
