### PR TITLE
Exclude clip-path-element-userSpaceOnUse-00{3,4}.html from interop-2023

### DIFF
--- a/css/css-masking/clip-path/META.yml
+++ b/css/css-masking/clip-path/META.yml
@@ -93,7 +93,6 @@ links:
         - test: clip-path-polygon-004.html
         - test: clip-path-polygon-008.html
         - test: clip-path-rotated-will-change-transform.html
-        - test: clip-path-element-userSpaceOnUse-004.html
         - test: clip-path-inline-002.html
         - test: clip-path-inset-round-percent.html
         - test: clip-path-path-002.html
@@ -121,7 +120,6 @@ links:
         - test: clip-path-viewBox-1c.html
         - test: svg-clip-path-fixed-values.html
         - test: clip-path-columns-shape-002.html
-        - test: clip-path-element-userSpaceOnUse-003.html
         - test: clip-path-ellipse-003.html
         - test: clip-path-polygon-001.html
         - test: clip-path-polygon-002.html


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/608

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
