### PR TITLE
Exclude {flex,grid}-align-baseline-table-002.html from interop-2023

### DIFF
--- a/css/css-flexbox/alignment/META.yml
+++ b/css/css-flexbox/alignment/META.yml
@@ -4,7 +4,6 @@ links:
         - test: flex-align-baseline-fieldset-001.html
         - test: flex-align-baseline-grid-001.html
         - test: flex-align-baseline-multicol-001.html
-        - test: flex-align-baseline-table-002.html
         - test: flex-align-baseline-002.html
         - test: flex-align-baseline-005.html
         - test: flex-align-baseline-flex-002.html

--- a/css/css-grid/alignment/META.yml
+++ b/css/css-grid/alignment/META.yml
@@ -621,7 +621,6 @@ links:
       results:
         - test: grid-align-baseline-002.html
         - test: grid-align-baseline-003.html
-        - test: grid-align-baseline-table-002.html
         - test: grid-content-alignment-overflow-002.html
         - test: grid-justify-baseline-005.html
         - test: grid-align-baseline-001.html


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/504
