### PR TITLE
Save PR number for auto-merge

### DIFF
--- a/.github/workflows/resolve_merge_conflict.yml
+++ b/.github/workflows/resolve_merge_conflict.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 jobs:
   resolve-merge-conflicts:
+    outputs:
+      prURL: ${{ steps.cpr.outputs.pull-request-url }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -21,6 +23,7 @@ jobs:
 
     - name: Create pull request
       uses: peter-evans/create-pull-request@v5
+      id: cpr
       with:
         token: ${{ secrets.WPTMETADATA_BOT_USER_PAT }}
         title: "Resolve pending metadata"


### PR DESCRIPTION
Auto-approve was enabled for [resolve_merge_conflict.yml](https://github.com/web-platform-tests/wpt-metadata/blob/master/.github/workflows/resolve_merge_conflict.yml), but the PR number appears to be missing in [the auto-merge step](https://github.com/web-platform-tests/wpt-metadata/actions/runs/7523062584/job/20475938240).

Taken from https://github.com/web-platform-tests/wpt-metadata/pull/4115