### PR TITLE
Add metadata of modulepreload bug for Chrome

### DIFF
--- a/loading/early-hints/META.yml
+++ b/loading/early-hints/META.yml
@@ -17,3 +17,8 @@ links:
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1874893
       results:
         - test: early-hints-response-time.h2.html
+    - product: chrome
+      url: https://crbug.com/1392720
+      results:
+        - test: modulepreload-as-worker.h2.window.html
+


### PR DESCRIPTION
In this PR, I add metadata for `loading/early-hints/modulepreload-as-worker.h2.window.html`.
I found the related bug (https://crbug.com/1392720) for the WPT when I investigated the WPT for Chrome.