### PR TITLE
Remove scope-starting-style.html from interop-2024-starting-style

### DIFF
--- a/css/css-cascade/META.yml
+++ b/css/css-cascade/META.yml
@@ -206,9 +206,6 @@ links:
   - subtest: Scoped nested group rule
     test: scope-nesting.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=1873614
-- label: interop-2024-starting-style
-  results:
-  - test: scope-starting-style.html
 - product: firefox
   results:
   - subtest: '@scope can match :host'


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/641
