### PR TITLE
Add chromium-bidi-2023 label

### DIFF
--- a/webdriver/tests/bidi/browsing_context/activate/META.yml
+++ b/webdriver/tests/bidi/browsing_context/activate/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: activate.py
+        - test: invalid.py

--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/META.yml
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/META.yml
@@ -17,3 +17,11 @@ links:
           subtest: test_clip_element
         - test: clip.py
           subtest: test_clip_viewport
+    - label: chromium-bidi-2023
+      results:
+        - test: capture_screenshot.py
+        - test: clip.py
+        - test: format.py
+        - test: frame.py
+        - test: invalid.py
+        - test: origin.py

--- a/webdriver/tests/bidi/browsing_context/classic_interop/META.yml
+++ b/webdriver/tests/bidi/browsing_context/classic_interop/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: window_handle.py

--- a/webdriver/tests/bidi/browsing_context/close/META.yml
+++ b/webdriver/tests/bidi/browsing_context/close/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: close.py
+        - test: invalid.py

--- a/webdriver/tests/bidi/browsing_context/context_created/META.yml
+++ b/webdriver/tests/bidi/browsing_context/context_created/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: context_created.py

--- a/webdriver/tests/bidi/browsing_context/context_destroyed/META.yml
+++ b/webdriver/tests/bidi/browsing_context/context_destroyed/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: context_destroyed.py

--- a/webdriver/tests/bidi/browsing_context/create/META.yml
+++ b/webdriver/tests/bidi/browsing_context/create/META.yml
@@ -1,0 +1,7 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: background.py
+        - test: invalid.py
+        - test: reference_context.py
+        - test: type.py

--- a/webdriver/tests/bidi/browsing_context/dom_content_loaded/META.yml
+++ b/webdriver/tests/bidi/browsing_context/dom_content_loaded/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: dom_content_loaded.py

--- a/webdriver/tests/bidi/browsing_context/fragment_navigated/META.yml
+++ b/webdriver/tests/bidi/browsing_context/fragment_navigated/META.yml
@@ -4,3 +4,7 @@ links:
       results:
         - test: fragment_navigated.py
           subtest: test_document_write
+    - label: chromium-bidi-2023
+      results:
+        - test: fragment_navigated.py
+        - test: history_api.py

--- a/webdriver/tests/bidi/browsing_context/get_tree/META.yml
+++ b/webdriver/tests/bidi/browsing_context/get_tree/META.yml
@@ -1,0 +1,7 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: frames.py
+        - test: invalid.py
+        - test: max_depth.py
+        - test: root.py

--- a/webdriver/tests/bidi/browsing_context/handle_user_prompt/META.yml
+++ b/webdriver/tests/bidi/browsing_context/handle_user_prompt/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: handle_user_prompt.py
+        - test: invalid.py

--- a/webdriver/tests/bidi/browsing_context/load/META.yml
+++ b/webdriver/tests/bidi/browsing_context/load/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: load.py

--- a/webdriver/tests/bidi/browsing_context/locate_nodes/META.yml
+++ b/webdriver/tests/bidi/browsing_context/locate_nodes/META.yml
@@ -1,0 +1,11 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: context.py
+        - test: invalid.py
+        - test: locator.py
+        - test: max_node_count.py
+        - test: ownership.py
+        - test: sandbox.py
+        - test: serialization_options.py
+        - test: start_nodes.py

--- a/webdriver/tests/bidi/browsing_context/navigate/META.yml
+++ b/webdriver/tests/bidi/browsing_context/navigate/META.yml
@@ -1,0 +1,12 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: about_blank.py
+        - test: data_url.py
+        - test: error.py
+        - test: frame.py
+        - test: hash.py
+        - test: image.py
+        - test: invalid.py
+        - test: navigate.py
+        - test: wait.py

--- a/webdriver/tests/bidi/browsing_context/navigation_started/META.yml
+++ b/webdriver/tests/bidi/browsing_context/navigation_started/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: navigation_started.py

--- a/webdriver/tests/bidi/browsing_context/print/META.yml
+++ b/webdriver/tests/bidi/browsing_context/print/META.yml
@@ -1,0 +1,12 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: background.py
+        - test: context.py
+        - test: invalid.py
+        - test: margin.py
+        - test: orientation.py
+        - test: page.py
+        - test: page_ranges.py
+        - test: scale.py
+        - test: shrink_to_fit.py

--- a/webdriver/tests/bidi/browsing_context/reload/META.yml
+++ b/webdriver/tests/bidi/browsing_context/reload/META.yml
@@ -12,3 +12,9 @@ links:
         - test: invalid.py
         - test: reload.py
         - test: wait.py
+    - label: chromium-bidi-2023
+      results:
+        - test: frame.py
+        - test: invalid.py
+        - test: reload.py
+        - test: wait.py

--- a/webdriver/tests/bidi/browsing_context/set_viewport/META.yml
+++ b/webdriver/tests/bidi/browsing_context/set_viewport/META.yml
@@ -4,3 +4,8 @@ links:
       results:
         - test: viewport.py
           subtest: test_set_viewport_persists_on_reload
+    - label: chromium-bidi-2023
+      results:
+        - test: device_pixel_ratio.py
+        - test: invalid.py
+        - test: viewport.py

--- a/webdriver/tests/bidi/browsing_context/traverse_history/META.yml
+++ b/webdriver/tests/bidi/browsing_context/traverse_history/META.yml
@@ -1,0 +1,6 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: context.py
+        - test: delta.py
+        - test: invalid.py

--- a/webdriver/tests/bidi/browsing_context/user_prompt_closed/META.yml
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_closed/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: user_prompt_closed.py

--- a/webdriver/tests/bidi/browsing_context/user_prompt_opened/META.yml
+++ b/webdriver/tests/bidi/browsing_context/user_prompt_opened/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: user_prompt_opened.py

--- a/webdriver/tests/bidi/errors/META.yml
+++ b/webdriver/tests/bidi/errors/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: errors.py

--- a/webdriver/tests/bidi/input/META.yml
+++ b/webdriver/tests/bidi/input/META.yml
@@ -1,4 +1,0 @@
-links:
-    - label: chromium-bidi-2023
-      results:
-        - test: conftest.py

--- a/webdriver/tests/bidi/input/META.yml
+++ b/webdriver/tests/bidi/input/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: conftest.py

--- a/webdriver/tests/bidi/input/perform_actions/META.yml
+++ b/webdriver/tests/bidi/input/perform_actions/META.yml
@@ -12,4 +12,19 @@ links:
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1658880
       results:
         - test: pointer_pen.py
-
+    - label: chromium-bidi-2023
+      results:
+        - test: invalid.py
+        - test: key.py
+        - test: key_events.py
+        - test: key_modifier.py
+        - test: pointer.py
+        - test: pointer_mouse.py
+        - test: pointer_mouse_drag.py
+        - test: pointer_mouse_modifier.py
+        - test: pointer_mouse_multiclick.py
+        - test: pointer_origin.py
+        - test: pointer_pen.py
+        - test: pointer_touch.py
+        - test: wheel.py
+        - test: wheel_origin.py

--- a/webdriver/tests/bidi/input/release_actions/META.yml
+++ b/webdriver/tests/bidi/input/release_actions/META.yml
@@ -1,0 +1,7 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: context.py
+        - test: invalid.py
+        - test: release.py
+        - test: sequence.py

--- a/webdriver/tests/bidi/log/entry_added/META.yml
+++ b/webdriver/tests/bidi/log/entry_added/META.yml
@@ -15,3 +15,12 @@ links:
           subtest: test_subscribe_unsubscribe[javascript_error]
         - test: subscription.py
           subtest: test_subscribe_unsubscribe[console_api_log]
+    - label: chromium-bidi-2023
+      results:
+        - test: console.py
+        - test: console_args.py
+        - test: event_buffer.py
+        - test: javascript.py
+        - test: realm.py
+        - test: stacktrace.py
+        - test: subscription.py

--- a/webdriver/tests/bidi/network/META.yml
+++ b/webdriver/tests/bidi/network/META.yml
@@ -1,4 +1,0 @@
-links:
-    - label: chromium-bidi-2023
-      results:
-        - test: conftest.py

--- a/webdriver/tests/bidi/network/META.yml
+++ b/webdriver/tests/bidi/network/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: conftest.py

--- a/webdriver/tests/bidi/network/add_intercept/META.yml
+++ b/webdriver/tests/bidi/network/add_intercept/META.yml
@@ -1,0 +1,8 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: add_intercept.py
+        - test: invalid.py
+        - test: phase_auth_required.py
+        - test: phases.py
+        - test: url_patterns.py

--- a/webdriver/tests/bidi/network/auth_required/META.yml
+++ b/webdriver/tests/bidi/network/auth_required/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: auth_required.py
+        - test: unsubscribe.py

--- a/webdriver/tests/bidi/network/before_request_sent/META.yml
+++ b/webdriver/tests/bidi/network/before_request_sent/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: before_request_sent.py

--- a/webdriver/tests/bidi/network/combined/META.yml
+++ b/webdriver/tests/bidi/network/combined/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: network_events.py

--- a/webdriver/tests/bidi/network/continue_request/META.yml
+++ b/webdriver/tests/bidi/network/continue_request/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: invalid.py

--- a/webdriver/tests/bidi/network/continue_response/META.yml
+++ b/webdriver/tests/bidi/network/continue_response/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: invalid.py

--- a/webdriver/tests/bidi/network/continue_with_auth/META.yml
+++ b/webdriver/tests/bidi/network/continue_with_auth/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: action.py
+        - test: invalid.py

--- a/webdriver/tests/bidi/network/fail_request/META.yml
+++ b/webdriver/tests/bidi/network/fail_request/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: invalid.py

--- a/webdriver/tests/bidi/network/provide_response/META.yml
+++ b/webdriver/tests/bidi/network/provide_response/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: invalid.py

--- a/webdriver/tests/bidi/network/remove_intercept/META.yml
+++ b/webdriver/tests/bidi/network/remove_intercept/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: invalid.py
+        - test: remove_intercept.py

--- a/webdriver/tests/bidi/network/response_completed/META.yml
+++ b/webdriver/tests/bidi/network/response_completed/META.yml
@@ -1,0 +1,6 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: response_completed.py
+        - test: response_completed_cached.py
+        - test: response_completed_status.py

--- a/webdriver/tests/bidi/network/response_started/META.yml
+++ b/webdriver/tests/bidi/network/response_started/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: response_started.py
+        - test: response_started_cached.py

--- a/webdriver/tests/bidi/script/META.yml
+++ b/webdriver/tests/bidi/script/META.yml
@@ -1,4 +1,0 @@
-links:
-    - label: chromium-bidi-2023
-      results:
-        - test: conftest.py

--- a/webdriver/tests/bidi/script/META.yml
+++ b/webdriver/tests/bidi/script/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: conftest.py

--- a/webdriver/tests/bidi/script/add_preload_script/META.yml
+++ b/webdriver/tests/bidi/script/add_preload_script/META.yml
@@ -1,0 +1,7 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: add_preload_script.py
+        - test: arguments.py
+        - test: invalid.py
+        - test: sandbox.py

--- a/webdriver/tests/bidi/script/call_function/META.yml
+++ b/webdriver/tests/bidi/script/call_function/META.yml
@@ -75,3 +75,25 @@ links:
     - url: https://wpt.fyi/results/webdriver/tests/bidi/script/call_function?sha=e29a79361e&label=master&max-count=1
       results:
         - test: invalid.py
+    - label: chromium-bidi-2023
+      results:
+        - test: arguments.py
+        - test: await_promise.py
+        - test: channel.py
+        - test: exception_details.py
+        - test: exception_details_await_promise.py
+        - test: function_declaration.py
+        - test: internal_id.py
+        - test: invalid.py
+        - test: invalid_tentative.py
+        - test: primitive_values.py
+        - test: realm.py
+        - test: remote_reference.py
+        - test: remote_values.py
+        - test: result_node.py
+        - test: result_ownership.py
+        - test: sandbox.py
+        - test: serialization_options.py
+        - test: strict_mode.py
+        - test: this.py
+        - test: user_activation.py

--- a/webdriver/tests/bidi/script/call_function/META.yml
+++ b/webdriver/tests/bidi/script/call_function/META.yml
@@ -85,7 +85,6 @@ links:
         - test: function_declaration.py
         - test: internal_id.py
         - test: invalid.py
-        - test: invalid_tentative.py
         - test: primitive_values.py
         - test: realm.py
         - test: remote_reference.py

--- a/webdriver/tests/bidi/script/classic_interop/META.yml
+++ b/webdriver/tests/bidi/script/classic_interop/META.yml
@@ -1,0 +1,5 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: node_shared_id.py
+        - test: window_reference.py

--- a/webdriver/tests/bidi/script/disown/META.yml
+++ b/webdriver/tests/bidi/script/disown/META.yml
@@ -3,5 +3,4 @@ links:
       results:
         - test: handles.py
         - test: invalid.py
-        - test: invalid_tentative.py
         - test: target.py

--- a/webdriver/tests/bidi/script/disown/META.yml
+++ b/webdriver/tests/bidi/script/disown/META.yml
@@ -1,0 +1,7 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: handles.py
+        - test: invalid.py
+        - test: invalid_tentative.py
+        - test: target.py

--- a/webdriver/tests/bidi/script/evaluate/META.yml
+++ b/webdriver/tests/bidi/script/evaluate/META.yml
@@ -46,7 +46,6 @@ links:
         - test: exception_details_await_promise.py
         - test: internal_id.py
         - test: invalid.py
-        - test: invalid_tentative.py
         - test: primitive_values.py
         - test: remote_values.py
         - test: result_node.py

--- a/webdriver/tests/bidi/script/evaluate/META.yml
+++ b/webdriver/tests/bidi/script/evaluate/META.yml
@@ -38,3 +38,19 @@ links:
           subtest: test_exception_details_await_promise[new Proxy({}, {})-expected32]
         - test: exception_details_await_promise.py
           subtest: test_exception_details_await_promise[(function*() { yield 'a'; })()-expected33]
+    - label: chromium-bidi-2023
+      results:
+        - test: await_promise.py
+        - test: evaluate.py
+        - test: exception_details.py
+        - test: exception_details_await_promise.py
+        - test: internal_id.py
+        - test: invalid.py
+        - test: invalid_tentative.py
+        - test: primitive_values.py
+        - test: remote_values.py
+        - test: result_node.py
+        - test: result_ownership.py
+        - test: sandbox.py
+        - test: strict_mode.py
+        - test: user_activation.py

--- a/webdriver/tests/bidi/script/get_realms/META.yml
+++ b/webdriver/tests/bidi/script/get_realms/META.yml
@@ -1,0 +1,8 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: context.py
+        - test: get_realms.py
+        - test: invalid.py
+        - test: sandbox.py
+        - test: type.py

--- a/webdriver/tests/bidi/script/message/META.yml
+++ b/webdriver/tests/bidi/script/message/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: message.py

--- a/webdriver/tests/bidi/script/realm_created/META.yml
+++ b/webdriver/tests/bidi/script/realm_created/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: realm_created.py

--- a/webdriver/tests/bidi/script/realm_destroyed/META.yml
+++ b/webdriver/tests/bidi/script/realm_destroyed/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: realm_destroyed.py

--- a/webdriver/tests/bidi/script/remove_preload_script/META.yml
+++ b/webdriver/tests/bidi/script/remove_preload_script/META.yml
@@ -1,0 +1,6 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: invalid.py
+        - test: remove_preload_script.py
+        - test: sandbox.py

--- a/webdriver/tests/bidi/session/new/META.yml
+++ b/webdriver/tests/bidi/session/new/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: connect.py

--- a/webdriver/tests/bidi/session/status/META.yml
+++ b/webdriver/tests/bidi/session/status/META.yml
@@ -1,0 +1,4 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: status.py

--- a/webdriver/tests/bidi/session/subscribe/META.yml
+++ b/webdriver/tests/bidi/session/subscribe/META.yml
@@ -1,0 +1,6 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: contexts.py
+        - test: events.py
+        - test: invalid.py

--- a/webdriver/tests/bidi/session/unsubscribe/META.yml
+++ b/webdriver/tests/bidi/session/unsubscribe/META.yml
@@ -1,0 +1,6 @@
+links:
+    - label: chromium-bidi-2023
+      results:
+        - test: contexts.py
+        - test: events.py
+        - test: invalid.py


### PR DESCRIPTION
This is based on the snapshot of `webdriver/tests/bidi/*` at the end of 2023, i.e. as of https://github.com/web-platform-tests/wpt/commit/2a639a9fe4cdefd4ecd124a3f30caf631150eea5.

This label helps the Chromium team track our implementation progress against a non-moving target. Please do not add new tests to this label.