### PR TITLE
Mark chromium bugs assignment with `product: chrome` (websockets HTTP URL)

### DIFF
--- a/websockets/META.yml
+++ b/websockets/META.yml
@@ -84,7 +84,8 @@ links:
         - test: Create-non-absolute-url.any.html
         - test: Create-non-absolute-url.any.worker.html
         - test: Create-url-with-windows-1252-encoding.html
-    - url: https://crbug.com/325979102
+    - product: chrome
+      url: https://crbug.com/325979102
       results:
         - test: Create-non-absolute-url.any.html
         - test: Create-non-absolute-url.any.worker.html


### PR DESCRIPTION
It seems this should have been marked with a product (though resolving this bug will presumably fix it for Edge, too), but the UI didn't provide an obvious way to do that.