### PR TITLE
Add dir-shadow-42.html to interop-2024-dir label.

### DIFF
--- a/html/dom/elements/global-attributes/META.yml
+++ b/html/dom/elements/global-attributes/META.yml
@@ -194,6 +194,7 @@ links:
   - test: dir-assorted.window.html
   - test: dir-shadow-06.html
   - test: dir-shadow-12.html
+  - test: dir-shadow-42.html
 - product: firefox
   results:
   - subtest: Test status


### PR DESCRIPTION
Fixes web-platform-tests/interop#638.