### PR TITLE
Updating metadata to reflect the renaming of mousemove_prevent_default_action

### DIFF
--- a/uievents/mouse/META.yml
+++ b/uievents/mouse/META.yml
@@ -2,12 +2,12 @@ links:
     - label: interop-2023-events
       results:
         - test: cancel-mousedown-in-subframe.html
-        - test: mousemove_prevent_default_action.tentative.html
+        - test: mousemove_prevent_default_action.html
         - test: attributes.html
     - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1823663
       results:
-        - test: mousemove_prevent_default_action.tentative.html
+        - test: mousemove_prevent_default_action.html
           subtest: dragstart event firing when mousemove event is prevented
     - product: chrome
       url: https://crbug.com/269917
@@ -16,7 +16,7 @@ links:
     - product: chrome
       url: https://crbug.com/346473
       results:
-        - test: mousemove_prevent_default_action.tentative.html
+        - test: mousemove_prevent_default_action.html
     - product: safari
       url: https://bugs.webkit.org/show_bug.cgi?id=262691
       results:
@@ -27,9 +27,9 @@ links:
     - product: safari
       url: https://bugs.webkit.org/show_bug.cgi?id=262878
       results:
-        - test: mousemove_prevent_default_action.tentative.html
+        - test: mousemove_prevent_default_action.html
           subtest: selectionchange event firing when mousemove event is prevented
-        - test: mousemove_prevent_default_action.tentative.html
+        - test: mousemove_prevent_default_action.html
           subtest: dragstart event firing when mousemove event is prevented
     - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1887560


### PR DESCRIPTION
Updating metadata to reflect the renaming of mousemove-default-action - https://github.com/web-platform-tests/wpt/commit/410ce797162d3c1d39ff5fa3a730eb79248110ea

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
