### PR TITLE
Add a CODEOWNERS file to ensure code changes get reviewed by humans

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Require human review for non-metadata changes.
+
+# Require human review for GitHub workflow and repository configuration.
+/.github/ @web-platform-tests/wpt-core-team @web-platform-tests/admins
+# Require human review for Go code changes.
+/go_test/ @web-platform-tests/wpt-core-team @web-platform-tests/admins
+/go_util/ @web-platform-tests/wpt-core-team @web-platform-tests/admins
+# Require human review for top-level Go code changes and repository configuration.
+/* @web-platform-tests/wpt-core-team @web-platform-tests/admins


### PR DESCRIPTION
We shouldn't let the auto-approve and auto-merge workflows handle Go code changes or GitHub workflow changes. Ideally we could restrict the workflow actions with a paths-ignore declaration, but that only applies to push/pull events, so a CODEOWNERS file seems like the next best thing.