### PR TITLE
Exclude human reviewers from automated manifest updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,11 @@
 /.github/ @web-platform-tests/wpt-core-team @web-platform-tests/admins
 # Require human review for Go code changes.
 /go_test/ @web-platform-tests/wpt-core-team @web-platform-tests/admins
+
+# Do not require human review for WPT Manifest changes.
+/go_test/MANIFEST.json
+/go_test/WPT_SHA.json
+
 /go_util/ @web-platform-tests/wpt-core-team @web-platform-tests/admins
 # Require human review for top-level Go code changes and repository configuration.
 /* @web-platform-tests/wpt-core-team @web-platform-tests/admins


### PR DESCRIPTION
This change excludes the WPT manifest updates from human review.

Ideally, it would be great to add the Github App as a CODEOWNER but that is not allowed. However, there is a workaround.

This workaround comes from this thread that discusses the same thing: https://github.com/orgs/community/discussions/23064#discussioncomment-8383923

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
