### PR TITLE
Remove existing Blob URL bug links

### DIFF
--- a/FileAPI/BlobURL/META.yml
+++ b/FileAPI/BlobURL/META.yml
@@ -1,22 +1,4 @@
 links:
-    - product: firefox
-      url: https://crbug.com/351867688
-      results:
-        - test: cross-partition.tentative.https.html
-          subtest: Blob URL shouldn't be revocable from a cross-partition iframe
-        - test: cross-partition.tentative.https.html
-          subtest: Blob URL shouldn't be revocable from a cross-partition dedicated worker
-        - test: cross-partition.tentative.https.html
-          subtest: Blob URL shouldn't be revocable from a cross-partition shared worker
-    - product: safari
-      url: https://crbug.com/351867688
-      results:
-        - test: cross-partition.tentative.https.html
-          subtest: Blob URL shouldn't be revocable from a cross-partition iframe
-        - test: cross-partition.tentative.https.html
-          subtest: Blob URL shouldn't be revocable from a cross-partition dedicated worker
-        - test: cross-partition.tentative.https.html
-          subtest: Blob URL shouldn't be revocable from a cross-partition shared worker
     - product: safari
       url: https://bugs.webkit.org/show_bug.cgi?id=277965
       results:


### PR DESCRIPTION
The bug in the cross-partition revoke test has been resolved, so the bug links can be removed