### PR TITLE
Add back upgrade transaction tests to Interop

### DIFF
--- a/IndexedDB/META.yml
+++ b/IndexedDB/META.yml
@@ -282,6 +282,22 @@ links:
         - test: transaction-scheduling-rw-scopes.any.worker.html
         - test: transaction-scheduling-within-database.any.html
         - test: transaction-scheduling-within-database.any.worker.html
+        - test: upgrade-transaction-deactivation-timing.any.html
+        - test: upgrade-transaction-deactivation-timing.any.serviceworker.html
+        - test: upgrade-transaction-deactivation-timing.any.sharedworker.html
+        - test: upgrade-transaction-deactivation-timing.any.worker.html
+        - test: upgrade-transaction-lifecycle-backend-aborted.any.html
+        - test: upgrade-transaction-lifecycle-backend-aborted.any.serviceworker.html
+        - test: upgrade-transaction-lifecycle-backend-aborted.any.sharedworker.html
+        - test: upgrade-transaction-lifecycle-backend-aborted.any.worker.html
+        - test: upgrade-transaction-lifecycle-committed.any.html
+        - test: upgrade-transaction-lifecycle-committed.any.serviceworker.html
+        - test: upgrade-transaction-lifecycle-committed.any.sharedworker.html
+        - test: upgrade-transaction-lifecycle-committed.any.worker.html
+        - test: upgrade-transaction-lifecycle-user-aborted.any.html
+        - test: upgrade-transaction-lifecycle-user-aborted.any.serviceworker.html
+        - test: upgrade-transaction-lifecycle-user-aborted.any.sharedworker.html
+        - test: upgrade-transaction-lifecycle-user-aborted.any.worker.html
         - test: value_recursive.htm
         - test: writer-starvation.htm
     - product: firefox


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/48686 expanded these IndexedDB tests to workers, but the automated merge in #6831 removed them. Given that the expanded tests still [pass](https://wpt.fyi/results/IndexedDB?label=experimental&label=master&aligned) in all browsers, I assume that we want them all labeled as Interop-2024.