### PR TITLE
Revert "[Interop2024] Remove pointerevent WPT for no pointer movement"

### DIFF
--- a/pointerevents/META.yml
+++ b/pointerevents/META.yml
@@ -202,6 +202,7 @@ links:
         - test: pointerup_after_pointerdown_target_removed.html?mouse
         - test: pointerevent_movementxy.html?mouse
         - test: pointerevent_fractional_coordinates.html?mouse
+        - test: pointerevent_pointerout_no_pointer_movement.html
         - test: pointerevent_touch-action-keyboard.html
         - test: idlharness.https.window.html
         - test: pointerevent_click_during_capture.html?mouse-click


### PR DESCRIPTION
Reverts web-platform-tests/wpt-metadata#6799

Discussion: https://github.com/web-platform-tests/interop/issues/695#issuecomment-2444882370