### PR TITLE
Upgrade Artifact actions v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr/


### PR DESCRIPTION
Upgrade [Artifact actions v4](https://github.com/actions/download-artifact). v3 will be deprecated by December 5, 2024
