### PR TITLE
Revert "Upgrade Artifact actions v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: pr_number
           path: pr/


### PR DESCRIPTION
Reverts web-platform-tests/wpt-metadata#6910. Looks like it broke the auto approve: 

https://github.com/web-platform-tests/wpt-metadata/actions/runs/11733818725/job/32688788109