### PR TITLE
Remove `frame_tentative.py` from `chromium-bidi-2023`

### DIFF
--- a/webdriver/tests/bidi/browsing_context/capture_screenshot/META.yml
+++ b/webdriver/tests/bidi/browsing_context/capture_screenshot/META.yml
@@ -14,7 +14,6 @@ links:
         - test: format.py
         - test: invalid.py
         - test: origin.py
-        - test: frame_tentative.py
     - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1861737
       results:


### PR DESCRIPTION
The `frame_tentative.py` was added by an automatically creted PR https://github.com/web-platform-tests/wpt-metadata/pull/6825 and is not relevant.