### PR TITLE
Revert Interop 2024 label changes

### DIFF
--- a/IndexedDB/META.yml
+++ b/IndexedDB/META.yml
@@ -66,6 +66,7 @@ links:
         - test: idbfactory-deleteDatabase-opaque-origin.html
         - test: idbfactory-open-opaque-origin.html
         - test: idbfactory-origin-isolation.html
+        - test: idbindex_indexNames.any.html
         - test: idbindex_keyPath.any.html
         - test: idbindex_keyPath.any.worker.html
         - test: idbindex_openCursor.any.html
@@ -78,9 +79,11 @@ links:
         - test: idbindex-getAll-enforcerange.any.html
         - test: idbindex-getAllKeys-enforcerange.any.html
         - test: idbindex-objectStore-SameObject.any.html
+        - test: idbindex-query-exception-order.any.html
         - test: idbindex-rename-abort.any.html
         - test: idbindex-rename-errors.any.html
         - test: idbindex-rename.any.html
+        - test: idbindex-request-source.any.html
         - test: idbobjectstore_get.any.html
         - test: idbobjectstore_get.any.worker.html
         - test: idbobjectstore_getAll.any.html


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/50809 inadvertently led to some Interop 2024 label changes as Kyle [pointed out](https://github.com/web-platform-tests/wpt/pull/50809#issuecomment-2675350017). This PR adds back the label to the non-worker variant as before.