### PR TITLE
Remove zoom-with-sign-function.html from the webcompat focus area.

### DIFF
--- a/css/css-viewport/zoom/META.yml
+++ b/css/css-viewport/zoom/META.yml
@@ -33,7 +33,6 @@ links:
         - test: svg.html
         - test: textarea-very-small-zoom-crash.html
         - test: word-spacing.html
-        - test: zoom-with-sign-function.html
         - test: stroke.html
         - test: svg-path.html
         - test: svg-viewBox.html


### PR DESCRIPTION
This fixes https://github.com/web-platform-tests/interop/issues/939
