### PR TITLE
[Interop 2025] Remove view transition tests relying on object-view-box

### DIFF
--- a/css/css-view-transitions/META.yml
+++ b/css/css-view-transitions/META.yml
@@ -381,7 +381,6 @@ links:
   - test: input-targets-root-while-render-blocked.html
   - test: iframe-new-has-scrollbar.html
   - test: root-captured-as-different-tag.html
-  - test: new-content-object-view-box-overflow-clipped.html
   - test: view-transition-name-removed-mid-transition.html
   - test: multiline-span-with-overflowing-text-and-box-decorations.html
   - test: new-content-captures-different-size.html
@@ -396,7 +395,6 @@ links:
   - test: massive-element-below-viewport-partially-onscreen-old.html
   - test: new-content-changes-overflow-left.html
   - test: capture-with-offscreen-child-translated.html
-  - test: old-content-object-view-box-clip-path.html
   - test: new-content-element-writing-modes.html
   - test: only-child-group.html
   - test: pseudo-element-overflow-hidden.html
@@ -426,7 +424,6 @@ links:
   - test: massive-element-on-top-of-viewport-offscreen-old.html
   - test: new-content-inline-with-offset-from-containing-block-clipped.html
   - test: no-white-flash-before-activation.html
-  - test: old-content-object-view-box-overflow.html
   - test: pseudo-with-classes-exit.html
   - test: span-with-overflowing-text-hidden.html
   - test: empty-render-target-crash.html
@@ -436,7 +433,6 @@ links:
   - test: capture-with-visibility-hidden-child.html
   - test: iframe-and-main-frame-transition-old-main-old-iframe.html
   - test: new-and-old-sizes-match.html
-  - test: new-content-object-view-box-overflow.html
   - test: new-root-vertical-writing-mode.html
   - test: update-callback-called-once.html
   - test: group-animation-for-root-transition.html
@@ -447,13 +443,11 @@ links:
   - test: new-content-transform-position-fixed.html
   - test: iframe-and-main-frame-transition-with-name-on-iframe.html
   - test: massive-element-left-of-viewport-partially-onscreen-new.html
-  - test: new-content-object-view-box-clip-path.html
   - test: pseudo-with-classes-match-multiple.html
   - test: root-element-cv-hidden-crash.html
   - test: set-current-time.html
   - test: active-view-transition-pseudo-class-match.html
   - test: css-tags-shared-element.html
-  - test: old-content-with-object-view-box.html
   - test: pseudo-with-classes-match-wildcard-no-star.html
   - test: massive-element-below-viewport-offscreen-new.html
   - test: offscreen-element-modified-before-coming-onscreen.html
@@ -467,7 +461,6 @@ links:
   - test: set-universal-specificity.html
   - test: css-tags-paint-order-with-entry.html
   - test: hit-test-unpainted-element-from-point.html
-  - test: object-view-box-new-image.html
   - test: massive-element-below-viewport-offscreen-old.html
   - test: massive-element-left-of-viewport-partially-onscreen-old.html
   - test: massive-element-left-of-viewport-offscreen-new.html
@@ -482,7 +475,6 @@ links:
   - test: old-content-captures-different-size.html
   - test: rotated-cat-off-top-edge.html
   - test: new-content-captures-positioned-spans.html
-  - test: new-content-with-object-view-box.html
   - test: old-content-escapes-clip-with-abspos-child.html
   - test: old-content-object-fit-fill.html
   - test: scroller-child.html
@@ -570,7 +562,6 @@ links:
   - test: view-transition-name-is-backdrop-filter-root.html
   - test: class-specificity.html
   - test: content-visibility-auto-shared-element.html
-  - test: old-content-object-view-box-clip-path-reference.html
   - test: shadow-part-with-name-nested.html
   - test: web-animation-pseudo-incorrect-name.html
   - test: iframe-transition.sub.html
@@ -592,7 +583,6 @@ links:
   - test: pseudo-with-classes-mismatch-partial.html
   - test: snapshot-containing-block-absolute.html
   - test: content-with-child-with-transparent-background.html
-  - test: object-view-box-old-image.html
   - test: root-to-shared-animation-end.html
   - test: transition-skipped-after-animation-started.html
   - test: snapshot-containing-block-includes-scrollbar-gutter.html
@@ -625,7 +615,6 @@ links:
   - test: shadow-part-with-class.html
   - test: dialog-in-top-layer-during-transition-old.html
   - test: new-content-container-writing-modes.html
-  - test: new-content-object-view-box-clip-path-reference.html
   - test: no-named-elements.html
   - test: pseudo-with-classes-mismatch-wildcard.html
   - test: iframe-and-main-frame-transition-new-main-old-iframe.html


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/940