### PR TITLE
Remove interop-2025-webcompat label from the wrong set of worker construction tests

### DIFF
--- a/workers/constructors/SharedWorker/META.yml
+++ b/workers/constructors/SharedWorker/META.yml
@@ -4,6 +4,3 @@ links:
       results:
         - test: interface-objects.html
           subtest: Test if interface objects exist in a shared worker
-    - label: interop-2025-webcompat
-      results:
-        - test: same-origin.html

--- a/workers/constructors/Worker/META.yml
+++ b/workers/constructors/Worker/META.yml
@@ -4,6 +4,3 @@ links:
       results:
         - test: DedicatedWorkerGlobalScope-members.worker.html
           status: FAIL
-    - label: interop-2025-webcompat
-      results:
-        - test: same-origin.html


### PR DESCRIPTION
Per discussion in https://github.com/web-platform-tests/interop/issues/932, remove the wpt/workers/constructors tests from the WebCompat focus area.

I couldn't figure out how to remove a label in the wpt.fyi site so I'm manually reverting their addition here.

The corresponding PR to add the correct set of tests is https://github.com/web-platform-tests/wpt-metadata/pull/7470.
