### PR TITLE
Remove no-painting-while-render-blocked.html from Interop 2025

### DIFF
--- a/css/css-view-transitions/META.yml
+++ b/css/css-view-transitions/META.yml
@@ -503,7 +503,6 @@ links:
   - test: old-content-object-fit-none.html
   - test: root-element-display-none-crash.html
   - test: hit-test-unpainted-element.html
-  - test: no-painting-while-render-blocked.html
   - test: paint-holding-in-iframe.html
   - test: element-with-overflow.html
   - test: fractional-box-with-shadow-new.html


### PR DESCRIPTION
Fixes web-platform-tests/interop#942