### PR TITLE
Remove invalid wasm memory labels

### DIFF
--- a/wasm/jsapi/memory/to-fixed-length-buffer.any.js/META.yml
+++ b/wasm/jsapi/memory/to-fixed-length-buffer.any.js/META.yml
@@ -1,4 +1,0 @@
-links:
-    - label: interop-2025-webassembly
-      results:
-        - test: '*'

--- a/wasm/jsapi/memory/to-resizable-buffer-shared.any.js/META.yml
+++ b/wasm/jsapi/memory/to-resizable-buffer-shared.any.js/META.yml
@@ -1,4 +1,0 @@
-links:
-    - label: interop-2025-webassembly
-      results:
-        - test: '*'

--- a/wasm/jsapi/memory/to-resizable-buffer.any.js/META.yml
+++ b/wasm/jsapi/memory/to-resizable-buffer.any.js/META.yml
@@ -1,4 +1,0 @@
-links:
-    - label: interop-2025-webassembly
-      results:
-        - test: '*'


### PR DESCRIPTION
These tests are correctly labelled in wasm/jsapi/memory/META.yml

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
