### PR TITLE
Remove event-timing/selection-autoscroll.html from Interop 2025

### DIFF
--- a/event-timing/META.yml
+++ b/event-timing/META.yml
@@ -123,5 +123,4 @@ links:
         - test: interactionid-tap.html
         - test: mouseout.html
         - test: only-observe-firstInput.html
-        - test: selection-autoscroll.html
         - test: supported-types-consistent-with-self.html


### PR DESCRIPTION
Fixes web-platform-tests/interop#962.