### PR TITLE
Remove largest-contentful-paint/video-data-uri.html from Interop 2025

### DIFF
--- a/largest-contentful-paint/META.yml
+++ b/largest-contentful-paint/META.yml
@@ -67,4 +67,3 @@ links:
         - test: resized-image-not-reconsidered.html
         - test: video-poster.html
         - test: element-only-when-fully-active.html
-        - test: video-data-uri.html


### PR DESCRIPTION
We have consensus in https://github.com/web-platform-tests/interop/issues/958