### PR TITLE
Remove test scope-implicit-crash-print from Interop 2025

### DIFF
--- a/css/css-cascade/META.yml
+++ b/css/css-cascade/META.yml
@@ -359,7 +359,6 @@ links:
         - test: scope-layer.html
         - test: scope-pseudo-element.html
         - test: scope-visited.html
-        - test: scope-implicit-crash-print.html
         - test: scope-name-defining-rules.html
         - test: scope-nesting.html
         - test: scope-shadow.html


### PR DESCRIPTION
https://github.com/web-platform-tests/interop/issues/974

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
