### PR TITLE
Remove event-timing/modal-dialog-interrupt-paint.html

### DIFF
--- a/event-timing/META.yml
+++ b/event-timing/META.yml
@@ -98,7 +98,6 @@ links:
         - test: click.html
         - test: first-input-shadow-dom.html
         - test: interaction-count-tap.html
-        - test: modal-dialog-interrupt-paint.html
         - test: dblclick.html
         - test: mouseup.html
         - test: pointerenter.html


### PR DESCRIPTION
This test is not currently on the spec, and [wpt.fyi/](wpt.fyi/) shows all browsers failing.

I tested [manually on wpt.live](http://wpt.live/event-timing/modal-dialog-interrupt-paint.html) and only chrome passes. It seems this is hard to test because of how modal dialogs block synchronously.

Considering the lack of spec support and difficulties with testing, it seems reasonable to remove this from Interop 2025.

Fixes https://github.com/web-platform-tests/interop/issues/1171
