### PR TITLE
Remove insertlinebreak.html from META.yml

### DIFF
--- a/editing/run/META.yml
+++ b/editing/run/META.yml
@@ -8,7 +8,6 @@ links:
       results:
         - test: delete.html?5001-6000
         - test: forwarddelete.html?5001-6000
-        - test: insertlinebreak.html
         - test: insertparagraph.html?1-1000
         - test: outdent.html?2001-last
     - product: chrome


### PR DESCRIPTION
This test has been renamed and should no longer be listed in the metadata.