### PR TITLE
Remove WebRTC back-forward cache test from interop 2026

### DIFF
--- a/webrtc/META.yml
+++ b/webrtc/META.yml
@@ -543,7 +543,6 @@ links:
         - test: RTCConfiguration-iceTransportPolicy.html?interop-2026
         - test: RTCDataChannel-send-close-array-buffer-negotiated.window.html
         - test: RTCPeerConnection-removeTrack.https.html
-        - test: back-forward-cache-with-open-webrtc-connection.https.window.html
         - test: RTCDTMFSender-ontonechange.https.html
         - test: RTCPeerConnection-getStats.https.html?interop-2026
         - test: RTCPeerConnection-operations.https.html?interop-2026


### PR DESCRIPTION
See https://github.com/w3c/webrtc-pc/issues/3100 for more discussions.