### PR TITLE
Remove deferred animation timeline test from Interop 2026

### DIFF
--- a/scroll-animations/css/META.yml
+++ b/scroll-animations/css/META.yml
@@ -254,7 +254,6 @@ links:
         - test: animation-range-visual-test.html
         - test: animation-shorthand.html
         - test: animation-timeline-computed.html
-        - test: animation-timeline-deferred.html
         - test: animation-timeline-in-keyframe.html
         - test: animation-timeline-multiple.html
         - test: animation-timeline-none.html


### PR DESCRIPTION
Removed 'animation-timeline-deferred.html' from the test list based on https://github.com/web-platform-tests/interop/issues/1276
