### PR TITLE
Update META.yml to remove obsolete WebTransport tests

### DIFF
--- a/webtransport/META.yml
+++ b/webtransport/META.yml
@@ -28,10 +28,7 @@ links:
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=2003955
 - label: interop-2026-webtransport
   results:
-  - test: back-forward-cache-with-closed-webtransport-connection-ccns.https.tentative.window.html
   - test: back-forward-cache-with-closed-webtransport-connection.https.window.html
-  - test: back-forward-cache-with-open-webtransport-connection-ccns.https.tentative.window.html
-  - test: back-forward-cache-with-open-webtransport-connection.https.window.html
   - test: bidirectional-cancel-crash.https.html
   - test: close.https.any.html
   - test: close.https.any.serviceworker.html


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/1278. Removed tests related to back-forward cache with closed and open WebTransport connections.
