### PR TITLE
Remove test for view-timeline-pseudo-on-scroller from Interop 2026

### DIFF
--- a/scroll-animations/css/META.yml
+++ b/scroll-animations/css/META.yml
@@ -313,7 +313,6 @@ links:
         - test: view-timeline-name-computed.html
         - test: view-timeline-name-parsing.html
         - test: view-timeline-name-shadow.html
-        - test: view-timeline-pseudo-on-scroller.html
         - test: view-timeline-range-animation.html
         - test: view-timeline-range-update-reversed-animation.html
         - test: view-timeline-range-update.html


### PR DESCRIPTION
Remove test for view-timeline-pseudo-on-scroller from Interop 2026 - https://github.com/web-platform-tests/interop/issues/1280
