### PR TITLE
Replace unload with pagehide for Interop 2026

### DIFF
--- a/navigation-api/ordering-and-transition/META.yml
+++ b/navigation-api/ordering-and-transition/META.yml
@@ -61,8 +61,6 @@ links:
         - test: anchor-download-intercept-reject.html?currententrychange
         - test: anchor-download-intercept-reject.html?no-currententrychange
         - test: back-same-document-intercept-reject.html?currententrychange
-        - test: back-cross-document-event-order-with-pagehide.html
-        - test: navigate-cross-document-event-order-with-pagehide.html
         # Carryover from Interop 2025
         - test: reload-intercept.html?currententrychange
         - test: transition-realms-and-identity.html

--- a/navigation-api/ordering-and-transition/META.yml
+++ b/navigation-api/ordering-and-transition/META.yml
@@ -2,11 +2,9 @@ links:
     - label: interop-2025-navigation
       results:
         - test: reload-intercept.html?currententrychange
-        - test: navigate-cross-document-event-order.html
         - test: transition-realms-and-identity.html
         - test: navigate-same-document-intercept-reentrant.html?currententrychange
         - test: navigate-double-intercept.html?no-currententrychange
-        - test: back-cross-document-event-order.html
         - test: navigate-canceled.html
         - test: location-href-intercept-reentrant.html?no-currententrychange
         - test: navigate-same-document.html?currententrychange
@@ -63,13 +61,13 @@ links:
         - test: anchor-download-intercept-reject.html?currententrychange
         - test: anchor-download-intercept-reject.html?no-currententrychange
         - test: back-same-document-intercept-reject.html?currententrychange
+        - test: back-cross-document-event-order-with-pagehide.html
+        - test: navigate-cross-document-event-order-with-pagehide.html
         # Carryover from Interop 2025
         - test: reload-intercept.html?currententrychange
-        - test: navigate-cross-document-event-order.html
         - test: transition-realms-and-identity.html
         - test: navigate-same-document-intercept-reentrant.html?currententrychange
         - test: navigate-double-intercept.html?no-currententrychange
-        - test: back-cross-document-event-order.html
         - test: navigate-canceled.html
         - test: location-href-intercept-reentrant.html?no-currententrychange
         - test: navigate-same-document.html?currententrychange


### PR DESCRIPTION
Based on the test change proposal - web-platform-tests/interop#1274, remove the tests with unload from Interop 2026 and replace with the new pagehide tests.

Depends on web-platform-tests/wpt#59853 being merged

