### PR TITLE
Remove webrtc/protocol/h264-profile-levels and ice-ufragpwd from Interop 2026

### DIFF
--- a/webrtc/protocol/META.yml
+++ b/webrtc/protocol/META.yml
@@ -205,7 +205,6 @@ links:
           subtest: Explicit offer/answer exchange gives a connection
     - label: interop-2026-webrtc
       results:
-        - test: h264-profile-levels.https.html?interop-2026
         - test: handover.html
         - test: rtp-payloadtypes.html?interop-2026
         - test: bundle.https.html?interop-2026
@@ -213,7 +212,6 @@ links:
         - test: video-codecs.https.html
         - test: codecs-subsequent-offer.https.html
         - test: handover-datachannel.html
-        - test: ice-ufragpwd.html
         - test: rtp-headerextensions.html
         - test: candidate-exchange.https.html?interop-2026
         - test: crypto-suite.https.html


### PR DESCRIPTION
Per discussion in https://github.com/w3c/webrtc-pc/issues/3100:

- h264-profile-levels.https.html?interop-2026 — agreement to remove, as tests pass for mid-range levels only by accident 
- ice-ufragpwd.html — remove due to test being wrong and won't pass 2/3 after fixing, per https://github.com/w3c/webrtc-pc/issues/3100#issuecomment-4407791140
