### PR TITLE
Add missing test grid-lanes-subgrid-flex.html to track-sizing/META.yml

### DIFF
--- a/css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/META.yml
+++ b/css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/META.yml
@@ -21,3 +21,7 @@ links:
   - test: column-subgrid-with-row-standalone-axis-size-003.html
   - test: column-subgrid-with-row-standalone-axis-size-004.html
   url: https://bugzilla.mozilla.org/show_bug.cgi?id=2039190
+- product: firefox
+  results:
+  - test: grid-lanes-subgrid-flex.html
+  url: https://bugzilla.mozilla.org/show_bug.cgi?id=2040337


### PR DESCRIPTION
I was fixing pull/8938 but mistakenly didn't include both tests. This PR adds the missing `grid-lanes-subgrid-flex.html` test to `css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/META.yml`.
