### PR TITLE
Replace unload with pagehide for Interop 2026 (part 2)

### DIFF
--- a/navigation-api/ordering-and-transition/META.yml
+++ b/navigation-api/ordering-and-transition/META.yml
@@ -61,6 +61,8 @@ links:
         - test: anchor-download-intercept-reject.html?currententrychange
         - test: anchor-download-intercept-reject.html?no-currententrychange
         - test: back-same-document-intercept-reject.html?currententrychange
+        - test: back-cross-document-event-order-with-pagehide.html
+        - test: navigate-cross-document-event-order-with-pagehide.html
         # Carryover from Interop 2025
         - test: reload-intercept.html?currententrychange
         - test: transition-realms-and-identity.html


### PR DESCRIPTION
Based on the test change proposal - web-platform-tests/interop#1274, tagging the newly addded pagehide tests for Interop 2026

Part 2 of #8942

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
