### PR TITLE
Remove range-boundary.html from Interop 2026

### DIFF
--- a/scroll-animations/view-timelines/META.yml
+++ b/scroll-animations/view-timelines/META.yml
@@ -77,7 +77,6 @@ links:
   - test: get-keyframes-with-timeline-offset.html
   - test: inline-subject.html
   - test: intermediate-transform.html
-  - test: range-boundary.html
   - test: subject-br-crash.html
   - test: svg-graphics-element-001.html
   - test: svg-graphics-element-002.html


### PR DESCRIPTION
range-boundary.html has been marked tentative. Remove from Interop 2026, till there is consensus on  handling of boundaries for view-timelines. Fixes web-platform-tests/interop#1292

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
