### PR TITLE
Revert "Update tests for Interop 2026 CSS shape focus area"

### DIFF
--- a/css/css-masking/clip-path/META.yml
+++ b/css/css-masking/clip-path/META.yml
@@ -168,23 +168,6 @@ links:
         - test: clip-path-mix-blend-mode-1.html
         - test: clip-path-reference-box-004.html
         - test: clip-path-svg-text-font-loading.html
-    - label: interop-2026-shape
-      results:
-        - test: clip-path-shape-001.html
-        - test: clip-path-shape-002-units.html
-        - test: clip-path-shape-002.html
-        - test: clip-path-shape-003.html
-        - test: clip-path-shape-004.html
-        - test: clip-path-shape-005.html
-        - test: clip-path-shape-006.html
-        - test: clip-path-shape-007.html
-        - test: clip-path-shape-008.html
-        - test: clip-path-shape-009.html
-        - test: clip-path-shape-010.html
-        - test: clip-path-shape-011.html
-        - test: clip-path-shape-foreignobject-non-zero-xy.html
-        - test: clip-path-shape-hline-vline-keywords.html
-        - test: clip-path-shape-winding.html
     - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1821793
       results:

--- a/css/css-masking/clip-path/animations/META.yml
+++ b/css/css-masking/clip-path/animations/META.yml
@@ -22,14 +22,6 @@ links:
         - test: clip-path-animation-overflow.html
         - test: clip-path-path-interpolation-001.html
         - test: clip-path-path-interpolation-002.html
-    - label: interop-2026-shape
-      results:
-        - test: clip-path-shape-arc-interpolation.html
-        - test: clip-path-shape-interpolation-001.html
-        - test: clip-path-shape-interpolation-002.html
-        - test: clip-path-shape-interpolation-003.html
-        - test: clip-path-shape-interpolation-004.html
-        - test: clip-path-shape-transition-with-zoom.html
     - product: chrome
       url: https://crbug.com/880983
       results:

--- a/css/css-shapes/shape-functions/META.yml
+++ b/css/css-shapes/shape-functions/META.yml
@@ -91,6 +91,27 @@ links:
         - test: xywh-function-valid.html
     - label: interop-2026-shape
       results:
+        - test: inset-function-computed.html
+        - test: inset-function-valid.html
+        - test: path-function-invalid.html
+        - test: polygon-function-valid.html
+        - test: rect-function-computed.html
+        - test: rect-function-invalid.html
+        - test: xywh-function-valid.html
+        - test: circle-function-valid.html
+        - test: ellipse-function-computed.html
+        - test: ellipse-function-invalid.html
+        - test: path-function-valid.html
         - test: shape-function-computed.html
         - test: shape-function-invalid.html
         - test: shape-function-valid.html
+        - test: xywh-function-computed.html
+        - test: ellipse-function-valid.html
+        - test: path-function-computed.html
+        - test: polygon-function-computed.html
+        - test: circle-function-invalid.html
+        - test: inset-function-invalid.html
+        - test: polygon-function-invalid.html
+        - test: rect-function-valid.html
+        - test: xywh-function-invalid.html
+        - test: circle-function-computed.html


### PR DESCRIPTION
Reverts web-platform-tests/wpt-metadata#9019 as I missed the do not merge label.