### PR TITLE
Remove capturing-snap-positions.html test from Interop 2026

### DIFF
--- a/css/css-scroll-snap/META.yml
+++ b/css/css-scroll-snap/META.yml
@@ -132,7 +132,6 @@ links:
         - test: scroll-margin-editable.html
         - test: scroll-target-align-001.html
         - test: scroll-target-align-003.html
-        - test: capturing-snap-positions.html
         - test: overscroll-snap.html
         - test: snap-fling-in-large-area.html
         - test: snap-on-focus.html


### PR DESCRIPTION
Fixes web-platform-tests/interop#1296
