### PR TITLE
Remove old labels for tests that have been removed

### DIFF
--- a/fetch/api/basic/META.yml
+++ b/fetch/api/basic/META.yml
@@ -101,22 +101,6 @@ links:
           subtest: Response reader read() promise should reject after a network error happening after resolving fetch promise
         - test: error-after-response.any.worker.html
           subtest: Response reader closed promise should reject after a network error happening after resolving fetch promise
-        - test: request-private-network-headers.tentative.any.sharedworker.html
-          subtest: Access-Control-Request-Private-Network is a forbidden request header
-        - test: request-private-network-headers.tentative.any.sharedworker.html
-          subtest: 'Adding invalid request header "Access-Control-Request-Private-Network: KO"'
-        - test: request-private-network-headers.tentative.any.html
-          subtest: Access-Control-Request-Private-Network is a forbidden request header
-        - test: request-private-network-headers.tentative.any.html
-          subtest: 'Adding invalid request header "Access-Control-Request-Private-Network: KO"'
-        - test: request-private-network-headers.tentative.any.serviceworker.html
-          subtest: Access-Control-Request-Private-Network is a forbidden request header
-        - test: request-private-network-headers.tentative.any.serviceworker.html
-          subtest: 'Adding invalid request header "Access-Control-Request-Private-Network: KO"'
-        - test: request-private-network-headers.tentative.any.worker.html
-          subtest: Access-Control-Request-Private-Network is a forbidden request header
-        - test: request-private-network-headers.tentative.any.worker.html
-          subtest: 'Adding invalid request header "Access-Control-Request-Private-Network: KO"'
         - test: request-upload.any.serviceworker.html
           subtest: Fetch with POST with ReadableStream containing String
         - test: request-upload.any.serviceworker.html


### PR DESCRIPTION
These labels are failing the CI here: https://github.com/web-platform-tests/wpt-metadata/pull/9073