### PR TITLE
Check live WPT manifest during CI when test paths are missing locally

### DIFF
--- a/go_test/test_paths_test.go
+++ b/go_test/test_paths_test.go
@@ -38,9 +38,13 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+func isLiveManifestFallbackEnabled() bool {
+	return strings.ToLower(strings.TrimSpace(os.Getenv("CI"))) == "true"
+}
+
 func getLiveManifest() (*shared.Manifest, error) {
 	liveManifestOnce.Do(func() {
-		log.Println("Test path missing from local MANIFEST.json; fetching live WPT manifest from", liveManifestURL)
+		log.Println("[NOTICE] Retrieving live WPT manifest from", liveManifestURL, "(CI=true)...")
 		resp, err := httpClient.Get(liveManifestURL)
 		if err != nil {
 			liveManifestErr = fmt.Errorf("failed to fetch live manifest: %w", err)
@@ -132,12 +136,17 @@ func TestResultsTestPaths(t *testing.T) {
 								ok, err = manifest.ContainsTest(fullPath)
 							}
 							if !ok || err != nil {
-								if liveM, lErr := getLiveManifest(); lErr == nil && liveM != nil {
-									if result.TestPath == "*" {
-										ok, err = liveM.ContainsFile(absFileDir)
-									} else {
-										ok, err = liveM.ContainsTest(fullPath)
+								if isLiveManifestFallbackEnabled() {
+									log.Printf("[NOTICE] Test path %q not found in local MANIFEST.json. Attempting live manifest check (enabled via CI=true)...", fullPath)
+									if liveM, lErr := getLiveManifest(); lErr == nil && liveM != nil {
+										if result.TestPath == "*" {
+											ok, err = liveM.ContainsFile(absFileDir)
+										} else {
+											ok, err = liveM.ContainsTest(fullPath)
+										}
 									}
+								} else {
+									log.Printf("[NOTICE] Test path %q not found in local MANIFEST.json. Live manifest fallback is disabled. To check against live upstream WPT manifest locally, run with: CI=true go test ./...", fullPath)
 								}
 							}
 							assert.Nil(t, err)
@@ -200,5 +209,13 @@ func TestLiveManifestFallback_LiveNetwork(t *testing.T) {
 	ok, err := liveM.ContainsTest("xhr/send-redirect.htm")
 	assert.Nil(t, err)
 	assert.True(t, ok)
+}
+
+func TestIsLiveManifestFallbackEnabled(t *testing.T) {
+	t.Setenv("CI", "true")
+	assert.True(t, isLiveManifestFallbackEnabled())
+
+	t.Setenv("CI", "false")
+	assert.False(t, isLiveManifestFallbackEnabled())
 }
 

--- a/go_test/test_paths_test.go
+++ b/go_test/test_paths_test.go
@@ -8,10 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	mapset "github.com/deckarep/golang-set"
@@ -20,6 +23,51 @@ import (
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
+
+var (
+	liveManifestURL  = "https://wpt.fyi/api/manifest?sha=latest"
+	httpClient       = &http.Client{}
+	liveManifestOnce sync.Once
+	liveManifest     *shared.Manifest
+	liveManifestErr  error
+)
+
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func getLiveManifest() (*shared.Manifest, error) {
+	liveManifestOnce.Do(func() {
+		log.Println("Test path missing from local MANIFEST.json; fetching live WPT manifest from", liveManifestURL)
+		resp, err := httpClient.Get(liveManifestURL)
+		if err != nil {
+			liveManifestErr = fmt.Errorf("failed to fetch live manifest: %w", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			liveManifestErr = fmt.Errorf("unexpected HTTP status code %d from live manifest endpoint", resp.StatusCode)
+			return
+		}
+
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			liveManifestErr = fmt.Errorf("failed to read live manifest: %w", err)
+			return
+		}
+
+		var m shared.Manifest
+		if err := json.Unmarshal(data, &m); err != nil {
+			liveManifestErr = fmt.Errorf("failed to unmarshal live manifest: %w", err)
+			return
+		}
+		liveManifest = &m
+	})
+	return liveManifest, liveManifestErr
+}
 
 // TestResultsTestPaths enumerates all the metadata in the repo and ensures that
 // a test by the given name exists in the latest manifest.
@@ -83,6 +131,15 @@ func TestResultsTestPaths(t *testing.T) {
 							} else {
 								ok, err = manifest.ContainsTest(fullPath)
 							}
+							if !ok || err != nil {
+								if liveM, lErr := getLiveManifest(); lErr == nil && liveM != nil {
+									if result.TestPath == "*" {
+										ok, err = liveM.ContainsFile(absFileDir)
+									} else {
+										ok, err = liveM.ContainsTest(fullPath)
+									}
+								}
+							}
 							assert.Nil(t, err)
 							assert.True(t, ok,
 								"%s is not a test path found in the manifest", fullPath)
@@ -94,3 +151,54 @@ func TestResultsTestPaths(t *testing.T) {
 		})
 	})
 }
+
+func TestLiveManifestFallback_Mock(t *testing.T) {
+	mockJSON := `{"version": 8, "items": {"testharness": {"mock": {"new-test.html": ["abcdef1234567890", [null, {}]]}}}}`
+	origTransport := httpClient.Transport
+	httpClient.Transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, liveManifestURL, req.URL.String())
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(strings.NewReader(mockJSON)),
+		}, nil
+	})
+
+	liveManifestOnce = sync.Once{}
+	liveManifest = nil
+	liveManifestErr = nil
+	defer func() {
+		httpClient.Transport = origTransport
+		liveManifestOnce = sync.Once{}
+		liveManifest = nil
+		liveManifestErr = nil
+	}()
+
+	liveM, err := getLiveManifest()
+	assert.Nil(t, err)
+	assert.NotNil(t, liveM)
+	ok, err := liveM.ContainsTest("mock/new-test.html")
+	assert.Nil(t, err)
+	assert.True(t, ok)
+}
+
+func TestLiveManifestFallback_LiveNetwork(t *testing.T) {
+	liveManifestOnce = sync.Once{}
+	liveManifest = nil
+	liveManifestErr = nil
+	defer func() {
+		liveManifestOnce = sync.Once{}
+		liveManifest = nil
+		liveManifestErr = nil
+	}()
+
+	liveM, err := getLiveManifest()
+	if err != nil {
+		t.Skipf("Skipping live network verification due to network/endpoint error or non-200 status: %v", err)
+		return
+	}
+	assert.NotNil(t, liveM)
+	ok, err := liveM.ContainsTest("xhr/send-redirect.htm")
+	assert.Nil(t, err)
+	assert.True(t, ok)
+}
+


### PR DESCRIPTION
Adhoc metadata PRs (such as Gecko sync or wpt.fyi triage) frequently add metadata for newly landed upstream WPT tests before the local go_test/MANIFEST.json rolls daily. This causes CI to fail with missing test errors and blocks automated PR resolution.

Update TestResultsTestPaths to perform an in-memory fallback lookup against https://wpt.fyi/api/manifest?sha=latest whenever a test path is not found locally. The live manifest is fetched at most once per test suite run using sync.Once.

Part of #9117
