### PR TITLE
Add optional GitHub token auth and manifest set sweeping (#9117)

### DIFF
--- a/.github/workflows/update_wpt_manifest.yml
+++ b/.github/workflows/update_wpt_manifest.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: run main
       run: ./main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create pull request
       id: cpr

--- a/rename_wpt/main.go
+++ b/rename_wpt/main.go
@@ -2,15 +2,36 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/google/go-github/v35/github"
 	"github.com/web-platform-tests/wpt-metadata/go_util"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"go.yaml.in/yaml/v4"
 )
+
+type authTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.token != "" {
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
 
 // This main() gets all the WPT test renaming and deletions between two WPT SHAs, then it deletes/renames
 // appropriately in the wpt-metadata repository. This program will roll in the latest WPT SHA once a day
@@ -34,19 +55,61 @@ func main() {
 
 	// Plumb the SHA information from a text file, WPT SHA rolls on a daily basis
 	renames, deletes := getChangesBetweenSHAs(context.Background(), shaBefore, shaAfter)
-	if renames == nil {
-		return
+	if renames != nil {
+		log.Println("Renaming WPT tests...")
+		for before, after := range renames {
+			renameMetadata(before, after)
+		}
+
+		log.Println("Deleting WPT tests...")
+		for _, delete := range deletes {
+			go_util.DeleteTestFromMetadata(delete)
+		}
 	}
 
-	fmt.Println("Renaming WPT tests...")
-	for before, after := range renames {
-		renameMetadata(before, after)
+	if manifestData, err := ioutil.ReadFile("go_test/MANIFEST.json"); err == nil {
+		var newManifest shared.Manifest
+		if err := json.Unmarshal(manifestData, &newManifest); err == nil {
+			sweepStaleMetadataAgainstManifest(&newManifest)
+		}
 	}
+}
 
-	fmt.Println("Deleting WPT tests...")
-	for _, delete := range deletes {
-		go_util.DeleteTestFromMetadata(delete)
-	}
+func sweepStaleMetadataAgainstManifest(manifest *shared.Manifest) {
+	log.Println("Sweeping repository for stale metadata against updated WPT manifest...")
+	filepath.Walk(".", func(filePath string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || strings.ToLower(info.Name()) != "meta.yml" {
+			return nil
+		}
+		fileDir := path.Dir(filePath)
+		data, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return nil
+		}
+		var metadata shared.Metadata
+		if err := yaml.Unmarshal(data, &metadata); err != nil {
+			return nil
+		}
+		for _, link := range metadata.Links {
+			for _, result := range link.Results {
+				if result.TestPath == "" {
+					continue
+				}
+				fullPath := path.Join(fileDir, result.TestPath)
+				var ok bool
+				if result.TestPath == "*" {
+					ok, _ = manifest.ContainsFile(fileDir)
+				} else {
+					ok, _ = manifest.ContainsTest(fullPath)
+				}
+				if !ok {
+					log.Printf("Pruning stale test path not found in latest manifest: %s", fullPath)
+					go_util.DeleteTestFromMetadata(fullPath)
+				}
+			}
+		}
+		return nil
+	})
 }
 
 // renameMetadata deletes the before WPT test and adds the after WPT test, if exists.
@@ -60,7 +123,7 @@ func renameMetadata(before, after string) {
 	// Rename the before test name to the after test name.
 	for linkIndex, link := range metadataLinks {
 		for resultIndex := range link.Results {
-			fmt.Println("Renaming", before, after)
+			log.Printf("Renaming %s to %s", before, after)
 			metadataLinks[linkIndex].Results[resultIndex].TestPath = afterTestname
 		}
 	}
@@ -75,15 +138,26 @@ func renameMetadata(before, after string) {
 // foo.any.html, foo.any.worker.html and foo.any.sharedworker.html. To perfectly rename/map all tests,
 // we need MANIFEST information.
 func getChangesBetweenSHAs(ctx context.Context, shaBefore, shaAfter string) (map[string]string, []string) {
-	fmt.Println("Getting WPT changes bewtween", shaBefore, "and", shaAfter)
+	log.Printf("Getting WPT changes between %s and %s", shaBefore, shaAfter)
 	if shaBefore == shaAfter {
-		fmt.Println("Nothing to do since the before/after SHAs are the same:", shaBefore)
+		log.Printf("Nothing to do since the before/after SHAs are the same: %s", shaBefore)
 		return nil, nil
 	}
-	githubClient := github.NewClient(nil)
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		token = os.Getenv("GH_TOKEN")
+	}
+	if token == "" {
+		token = os.Getenv("WPTMETADATA_BOT_USER_PAT")
+	}
+	var tc *http.Client
+	if token != "" {
+		tc = &http.Client{Transport: &authTransport{token: token}}
+	}
+	githubClient := github.NewClient(tc)
 	comparison, _, err := githubClient.Repositories.CompareCommits(ctx, "web-platform-tests", "wpt", shaBefore, shaAfter)
 	if err != nil || comparison == nil {
-		fmt.Println("Failed to fetch diff for", shaBefore[:7], shaAfter[:7], ":", err.Error())
+		log.Printf("Failed to fetch diff for %s %s: %v", shaBefore[:7], shaAfter[:7], err)
 		return nil, nil
 	}
 

--- a/rename_wpt/main_test.go
+++ b/rename_wpt/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func TestSweepStaleMetadataAgainstManifest(t *testing.T) {
+	tempDir := t.TempDir()
+	origDir, err := os.Getwd()
+	assert.NoError(t, err)
+	err = os.Chdir(tempDir)
+	assert.NoError(t, err)
+	defer os.Chdir(origDir)
+
+	err = os.MkdirAll("testdir", 0755)
+	assert.NoError(t, err)
+
+	metaPath := filepath.Join("testdir", "META.yml")
+	initialYAML := []byte(`links:
+  - product: chrome
+    url: https://external.com/item
+    results:
+    - test: valid.html
+    - test: stale.html
+`)
+	err = os.WriteFile(metaPath, initialYAML, 0644)
+	assert.NoError(t, err)
+
+	mockManifestJSON := []byte(`{
+		"version": 8,
+		"items": {
+			"testharness": {
+				"testdir": {
+					"valid.html": ["abcdef1234567890", [null, {}]]
+				}
+			}
+		}
+	}`)
+	var mockManifest shared.Manifest
+	err = json.Unmarshal(mockManifestJSON, &mockManifest)
+	assert.NoError(t, err)
+
+	sweepStaleMetadataAgainstManifest(&mockManifest)
+
+	finalBytes, err := os.ReadFile(metaPath)
+	assert.NoError(t, err)
+	finalStr := string(finalBytes)
+
+	assert.Contains(t, finalStr, "valid.html")
+	assert.NotContains(t, finalStr, "stale.html")
+}


### PR DESCRIPTION
Unauthenticated GitHub API calls in rename_wpt/main.go hit rate limits of 60 req/hr on shared CI runners. Read GITHUB_TOKEN / GH_TOKEN / WPTMETADATA_BOT_USER_PAT from the environment and inject Authorization headers when present, boosting the rate limit to 5,000 req/hr while preserving unauthenticated fallback for local runs.

Additionally, leverage WPT manifest set lookups (ContainsTest) to sweep and prune stale META.yml entries against the updated daily manifest in rename_wpt/main.go. Any test URL present in META.yml that no longer exists in the updated WPT manifest is pruned cleanly and deterministically with exact string matching.

Part of #9117

TAG=agy
CONV=151bab34-ef13-4f42-a878-c25d60599679

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
