### PR TITLE
Remove test entry for currententrychange before popstate from Interop 2026

### DIFF
--- a/navigation-api/ordering-and-transition/META.yml
+++ b/navigation-api/ordering-and-transition/META.yml
@@ -78,7 +78,6 @@ links:
         - test: reload-canceled.html
         - test: reload-intercept.html?no-currententrychange
         - test: location-href-intercept-reentrant.html?currententrychange
-        - test: currententrychange-before-popstate-intercept.html
         - test: navigate-same-document.html?no-currententrychange
         - test: navigate-same-document-intercept-reentrant.html?no-currententrychange
         - test: reload-intercept-reject.html?no-currententrychange


### PR DESCRIPTION
Addresses web-platform-tests/interop#1297