### PR TITLE
Drop pseudo-element-overflow-clip-with-border-radius.html from Interop 2026

### DIFF
--- a/css/css-view-transitions/META.yml
+++ b/css/css-view-transitions/META.yml
@@ -840,7 +840,6 @@ links:
   - test: view-transition-types-matches.html
   - test: view-transition-types-removed.html
   - test: view-transition-types-stay.html
-  - test: pseudo-element-overflow-clip-with-border-radius.html
   - test: small-scale.html
   - test: snapshot-containing-block-static-iframe.html
   - test: start-skip-start.html


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/interop/issues/1305