### PR TITLE
Remove /css/css-scroll-snap/snap-fling-in-large-area.html from Interop 2026

### DIFF
--- a/css/css-scroll-snap/META.yml
+++ b/css/css-scroll-snap/META.yml
@@ -133,7 +133,6 @@ links:
         - test: scroll-target-align-001.html
         - test: scroll-target-align-003.html
         - test: overscroll-snap.html
-        - test: snap-fling-in-large-area.html
         - test: snap-on-focus.html
         - test: snap-to-combination-of-two-elements-1.html
         - test: resnap-on-snap-alignment-change.html


### PR DESCRIPTION
Fixes web-platform-tests/interop#1310