### PR TITLE
Remove navigation API tests that depend on scroll anchoring from Interop 2026

### DIFF
--- a/navigation-api/scroll-behavior/META.yml
+++ b/navigation-api/scroll-behavior/META.yml
@@ -25,9 +25,7 @@ links:
         - test: manual-scroll-fragment-does-not-exist.html
         - test: manual-scroll-in-precommit-handler.html
         - test: manual-scroll-reload-no-scroll-anchoring.html
-        - test: manual-scroll-reload.html
         - test: after-transition-reload-no-scroll-anchoring.html
-        - test: after-transition-reload.html
         # Carryover from Interop 2025
         - test: after-transition-push.html
         - test: after-transition-timing.html


### PR DESCRIPTION
Remove the following from `interop-2026-navigation`:

- `navigation-api/scroll-behavior/after-transition-reload.html`
- `navigation-api/scroll-behavior/manual-scroll-reload.html`

These two tests depend on scroll anchoring behavior, which is out of scope for the navigation API focus area.

The equivalent coverage is already labeled for Interop 2026 without that dependency:

- `navigation-api/scroll-behavior/after-transition-reload-no-scroll-anchoring.html`
- `navigation-api/scroll-behavior/manual-scroll-reload-no-scroll-anchoring.html`

These exercise the navigation API relevant behavior without relying on scroll anchoring, so removing the two originals does not reduce what the focus area measures.