### PR TITLE
Clean up Firefox test cases in META.yml

### DIFF
--- a/webdriver/tests/classic/perform_actions/META.yml
+++ b/webdriver/tests/classic/perform_actions/META.yml
@@ -42,11 +42,6 @@ links:
         - test: pointer_tripleclick.py
           subtest: test_tripleclick_at_coordinates
     - product: firefox
-      url: https://bugzilla.mozilla.org/show_bug.cgi?id=1951086
-      results:
-        - test: wheel.py
-          subtest: test_scroll_iframe
-    - product: firefox
       url: https://bugzilla.mozilla.org/show_bug.cgi?id=1989456
       results:
         - test: navigation.py


### PR DESCRIPTION
The test was moved to [wheel_frame.py](https://wpt.fyi/results/webdriver/tests/classic/perform_actions/wheel_frame.py?label=master&label=experimental&product=firefox&product=firefox_android&product=chrome&product=chrome_android&product=safari&view=subtest) but it's also passing for quite a long time.